### PR TITLE
Add `contact_info` to ServiceInfo.

### DIFF
--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -353,7 +353,9 @@ definitions:
         type: string
         description: |-
           An email address or web page URL with contact information
-          for the operator of a specific WES endpoint.
+          for the operator of a specific WES endpoint.  Users of the
+          endpoint should use this to report problems or security
+          vulnerabilities.
       tags:
         type: object
         additionalProperties:

--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -347,8 +347,13 @@ definitions:
       auth_instructions_url:
         type: string
         description: |-
-          A URL that will help a in generating the tokens necessary to run a workflow using this
-          service.
+          A web page URL with information about how to get an
+          authorization token necessary to use a specific endpoint.
+     contact_info:
+        type: string
+        description: |-
+          An email address or web page URL with contact information
+          for the operator of a specific WES endpoint.
       tags:
         type: object
         additionalProperties:


### PR DESCRIPTION
This is simply an additional field to ServiceInfo that should provide a way to contact the operator of a given WES endpoint.