### PR TITLE
delete -> cancel

### DIFF
--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -231,7 +231,8 @@ paths:
           type: string
       tags:
         - WorkflowExecutionService
-    delete:
+  /runs/{run_id}/cancel:
+    post:
       summary: Cancel a running workflow.
       x-swagger-router-controller: ga4gh.wes.server
       operationId: CancelRun


### PR DESCRIPTION
I'm following the same approach as the Cromwell API:

https://cromwell.readthedocs.io/en/develop/api/RESTAPI/

DELETE now is a new endpoint /runs/{run_id}/cancel and this is done via a POST.  

This was done because DELETE implies the record of this run is purged.

See issue #95 