### PR TITLE
update build scripts, docs to treat 'master' as default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
         password:
           secure: LlQn8ZBAb5ekujHnoDrmzrmXaM6TpyzByNHPH4FTbbdnJ8lkDPb/ZhYvdmqrOvXPQg81/IoYKlIvP7fY9kc3oGUJ2IXhcPFqiw8njsRE5Qaebp+YppQO7C3IWGlHoZtXNtC608ZSA4x0oneNeNy+Y8KYnqKbmOlbuvrYRlNYfe9/8z7yLPH8wdmp0GyvbViedr3p7PXhtQVUKAgPpgjffZnSA7P/Y6AdkvjHHv2xMAzWP/QmOFWZNxUXjg0miR0K7eGFeGBNMM/+QsVXrGOu/TCtPtJ4JXyD86nzrZUbsOluyAblxwGlrv05se5ImVhR210OC5zvSW2902y/lxCw5uek+xg4/tcSA1ckshxLeu02GfDygCktMUtqtKVIZ+qvU7H4dEQ6Jnz9yBvZW5M6V94Ew3wBFy0RB5I9k3MMQY21FdynIUEZzBgJbOChCbmlIDT1varBHvWBiwg8EwPOVuJt1CsOoptJxUsoJND4tAOPIvXMNI17qGJ+VWAVMVNn7cVUuhEeGXwQF4urrkFBA7WIYOp6O9R8Ipg6WnQdxVdnqb3NsEc19SRdFXQ82SYibKfIZxjpdmYVgKzTYsJGMhfG6fTw9D4JABhggfgShsnByrFtbbkn/9g64jXDOjwPLeRXwXYZe6ZV6M69PDWdo0o326Qq/OHBG5eU7z2plNI=
 
-    - stage: build_docs
+    - stage: build_pages
       language: java
       jdk: oraclejdk8
       before_install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,12 @@ Even those with write access to the main repository should in general create pul
 
 > To facilitate review of external pull requests, users are encouraged to activate [**Travis CI**](https://travis-ci.org/) to monitor the build status (documentation, Swagger UI) of their fork. By following the documentation for [deployment to GitHub Pages](https://docs.travis-ci.com/user/deployment/pages/) and adding a `$GITHUB_TOKEN` environment variable to their repo configuration, pushes to the forked repo should be viewable relative to `https://[user-or-org].github.io/workflow-execution-service-schemas/preview/<branch>/`:
 
-+ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/[branch]/docs/
-+ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/[branch]/swagger-ui/
-+ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/[branch]/swagger.json
-+ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/[branch]/swagger.yaml
++ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/\<branch\>/docs/
++ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/\<branch\>/swagger-ui/
++ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/\<branch\>/swagger.json
++ https://[user-or-org].github.io/workflow-execution-service-schemas/preview/\<branch\>/swagger.yaml
 
-> Providing this base URL in the pull request comment is appreciated, but not required. When creating a pull request from the forked repository's `develop` branch, the base URL will just be `https://[user-or-org].github.io/workflow-execution-service-schemas/`.
+> Providing this base URL in the pull request comment is appreciated, but not required.
 
 If a security vulnerability is identified with the specification please send an email to security-notification@ga4gh.org detailing your concerns.
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The [Global Alliance for Genomics and Health](http://genomicsandhealth.org/) is 
 Cloud Work Stream
 -----------------
 
-The [Cloud Work Stream](https://ga4gh/cloud) helps the genomics and health communities take full advantage of modern cloud environments.
+The [Cloud Work Stream](https://ga4gh.cloud) helps the genomics and health communities take full advantage of modern cloud environments.
 Our initial focus is on “bringing the algorithms to the data”, by creating standards for defining, sharing, and executing portable workflows.
+
 We work with platform development partners and industry leaders to develop standards that will facilitate interoperability.
 
 What is WES?
@@ -33,13 +34,15 @@ API Definition
 See the human-readable [Reference Documentation](https://ga4gh.github.io/workflow-execution-service-schemas/docs/) 
 and the [OpenAPI YAML description](openapi/workflow_execution_service.swagger.yaml). You can also explore the specification in the [Swagger UI](https://ga4gh.github.io/workflow-execution-service-schemas/swagger-ui/) or [Swagger Editor](https://editor.swagger.io/?url=https://ga4gh.github.io/workflow-execution-service-schemas/swagger.yaml).
 
+> All documentation and pages hosted at 'ga4gh.github.io/workflow-execution-service' reflect the latest API release from the `master` branch. To monitor the latest development work, add 'preview/\<branch\>' to the URLs above (e.g., 'ga4gh.github.io/ga4gh.github.io/workflow-execution-service/preview/\<branch\>/docs'). To view the latest *stable* development API specification, refer to the `develop` branch.
+
 Use Cases
 ---------
 
 Use cases include:
 
 * "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
-* Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. [Dockstore.org](http://dockstore.org)), and run them over their data
+* Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g., [Dockstore.org](http://dockstore.org)), and run them over their data
 
 Possible Future Enhancements
 ----------------------------

--- a/scripts/fetchpages.sh
+++ b/scripts/fetchpages.sh
@@ -8,7 +8,11 @@ rm -rf .ghpages-tmp
 mkdir -p .ghpages-tmp
 cd .ghpages-tmp
 git clone --depth=1 --branch=gh-pages $REPO_URL .
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+cp -Rn . ../
+else
 cp -Rn preview ../preview/
+fi
 cd ..
 rm -rf .ghpages-tmp
 

--- a/scripts/stagepages.sh
+++ b/scripts/stagepages.sh
@@ -3,11 +3,11 @@
 set -e
 set -v
 
-if [ "$TRAVIS_BRANCH" == "develop" ]; then
+if [ "$TRAVIS_BRANCH" == "master" ]; then
     cp docs/html5/index.html docs/
     cp openapi/workflow_execution_service.swagger.yaml ./swagger.yaml
     cp -R web_deploy/* .
-elif [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_BRANCH" != "gh-pages" ]; then
+elif [ "$TRAVIS_BRANCH" != "gh-pages" ]; then
   branch=$(echo "$TRAVIS_BRANCH" | awk '{print tolower($0)}')
   branchpath="preview/$branch"
   mkdir -p "$branchpath/docs"


### PR DESCRIPTION
Still need to change repo settings to make `master` default for new visitors, but this should cover most of the docs/pages/badges issues.