### PR TITLE
Fix OpenAPI ServiceInfo validation error

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -466,15 +466,15 @@ components:
               additionalProperties:
                 type: string
                 description: A message containing useful information about the running service, including supported versions and default settings.
-            required:
-              - workflow_type_versions
-              - supported_wes_versions
-              - supported_filesystem_protocols
-              - workflow_engine_versions
-              - default_workflow_engine_parameters
-              - system_state_counts
-              - auth_instructions_url
-              - tags
+          required:
+            - workflow_type_versions
+            - supported_wes_versions
+            - supported_filesystem_protocols
+            - workflow_engine_versions
+            - default_workflow_engine_parameters
+            - system_state_counts
+            - auth_instructions_url
+            - tags
     State:
       title: State
       enum:


### PR DESCRIPTION
It looks like the indentation in the current spec is not right and causes OpenAPI spec error: 
```
 curl -X GET "https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fraw.githubusercontent.com%2Fga4gh%2Fworkflow-execution-service-schemas%2Fmaster%2Fopenapi%2Fworkflow_execution_service.openapi.yaml" -H "accept: application/yaml"
```
causes
```
messages:
- "attribute components.schemas.ServiceInfo.properties is not of type `object`"
schemaValidationMessages:
- level: "error"
  domain: "validation"
  keyword: "oneOf"
  message: "instance failed to match exactly one schema (matched 0 out of 2)"
  schema:
    loadingURI: "#"
    pointer: "/definitions/Components/properties/schemas/patternProperties/^[a-zA-Z0-9\\\
      .\\-_]+$"
  instance:
    pointer: "/components/schemas/ServiceInfo"
  required: null
  missing: null
```
whereas:
```
curl -X GET "https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fraw.githubusercontent.com%2Faniewielska%2Fworkflow-execution-service-schemas%2Ffix-service-info%2Fopenapi%2Fworkflow_execution_service.openapi.yaml" -H "accept: application/yaml"
```
returns no validation messages. 