### PR TITLE
fix: return RunStatus, not State, in RunListResponse

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -813,7 +813,7 @@ components:
         runs:
           type: array
           items:
-            $ref: '#/components/schemas/State'
+            $ref: '#/components/schemas/RunStatus'
           description: A list of workflow runs that the service has executed or is executing. The list is filtered to only include runs that the caller has permission to see.
         next_page_token:
           type: string


### PR DESCRIPTION
Addresses the regression described [here](https://github.com/ga4gh/workflow-execution-service-schemas/pull/172#discussion_r1068109227) and [here](https://github.com/ga4gh/workflow-execution-service-schemas/pull/172#discussion_r1068147005).