### PR TITLE
feat: add alternative schema for array items in RunListResponse

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -651,9 +651,6 @@ components:
         - $ref: '#/components/schemas/RunStatus'
         - type: object
           properties:
-            name:
-              type: string
-              description: The workflow name
             start_time:
               type: string
               description: When the run started executing, in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
@@ -666,9 +663,6 @@ components:
               additionalProperties:
                 type: string
           required:
-            - name
-            - start_time
-            - end_time
             - tags
       description: Small description of a workflow run
     RunRequest:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -71,6 +71,10 @@ tags:
     x-displayName: RunStatus
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/RunStatus" />
+  - name: runsummary_model
+    x-displayName: RunSummary
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/RunSummary" />
   - name: runrequest_model
     x-displayName: RunRequest
     description: |
@@ -111,6 +115,7 @@ x-tagGroups:
       - runid_model
       - state_model
       - runstatus_model
+      - runsummary_model
       - runrequest_model
       - runlog_model
       - log_model
@@ -639,7 +644,33 @@ components:
           type: string
         state:
           $ref: '#/components/schemas/State'
-      description: Small description of a workflow run, returned by server during listing
+      description: State information of a workflow run
+    RunSummary:
+      title: RunSummary
+      allOf:
+        - $ref: '#/components/schemas/RunStatus'
+        - type: object
+          properties:
+            name:
+              type: string
+              description: The workflow name
+            start_time:
+              type: string
+              description: When the run started executing, in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
+            end_time:
+              type: string
+              description: When the run stopped executing (completed, failed, or cancelled), in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
+            tags:
+              type: object
+              description: Arbitrary key/value tags added by the client during run creation 
+              additionalProperties:
+                type: string
+          required:
+            - name
+            - start_time
+            - end_time
+            - tags
+      description: Small description of a workflow run
     RunRequest:
       title: RunRequest
       type: object
@@ -813,12 +844,18 @@ components:
         runs:
           type: array
           items:
-            $ref: '#/components/schemas/RunStatus'
+            anyOf:
+              - $ref: '#/components/schemas/RunStatus'
+              - $ref: '#/components/schemas/RunSummary'
           description: A list of workflow runs that the service has executed or is executing. The list is filtered to only include runs that the caller has permission to see.
         next_page_token:
           type: string
           description: A token which may be supplied as `page_token` in workflow run list request to get the next page of results.  An empty string indicates there are no more items to return.
-      description: The service will return a RunListResponse when receiving a successful RunListRequest.
+      description: >
+              The service will return a RunListResponse when receiving a successful RunListRequest.
+              DEPRECIATION WARNING: The use of `RunStatus` as the schema for `runs` array items will
+              not be permitted from the next major version of the specification (2.0.0) onwards. We
+              encourage implementers to use `RunSummary` instead.
     ErrorResponse:
       title: ErrorResponse
       type: object


### PR DESCRIPTION
Alternative to #172 
Closes #165

This PR differs from #172 in the following ways:
- A **separate schema `RunSummary`** is defined, to be used specifically for the `runs` array items in `RunListResponse`
- `RunSummary` **extends `RunStatus` (not modified!) with `required` additional fields**
- For backward compatibility, either **`RunSummary` or `RunStatus` (`anyOf`) are acceptable** responses for `GET /runs`
- Next to `start_time` and `end_time`, also workflow `name` and `tags` are included in the extended response; `workflow_url` was not included, as it can point to a local object and its support would therefore require WES to serve objects (up for debate of course, following #172 and #165)

Taken together, this proposal avoids or partly addresses the following [concerns raised against #172](https://github.com/ga4gh/workflow-execution-service-schemas/pull/172#pullrequestreview-1368081769):
- ***"Proposal has side effects:"*** By using a separate schema to accommodate the additional metadata fields to be returned in run list responses, the `RunStatus` schema remains untouched, thus retaining the behavior of `GET /runs/{run_id}/status` (which also uses `RunStatus`).
- ***"Implementers may choose to ignore added fields":*** While implementers can still return `RunStatus` instead of `RunSummary` (or indeed any other response that has the `run_id` and `state` properties) in run list responses for backward compatibility (`anyOf`), this PR adds a couple of measures to more strongly encourage the use of the new extended schema. In particular,
  - A `DEPRECIATION WARNING` is added to the description of `RunListResponse`, informing implementers that the use of `RunStatus` in `RunListResponse` will be discontinued in favor of `RunSchema` only.
  - The new schema ***requires*** the additional fields in `RunSummary`, which - together with the depreciation warning - should tell every implementer clearly where the specs will be going in this respect; indeed, as soon as support for `RunStatus` in `RunListResponse` is removed (a simple change), any compliant implementation MUST provide these additional fields in their run list responses.

**It does NOT address the concern that _"clients may not agree with selection of fields"_**.