### PR TITLE
Release v1.1.0

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Workflow Execution Service
   contact: {}
-  version: '1.0.1'
+  version: '1.1.0'
   x-logo:
     url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
   description: >


### PR DESCRIPTION
## Summary

This release is being created to ensure versioning correctness and  is equivalent to [v1.0.1](https://github.com/ga4gh/workflow-execution-service-schemas/releases/tag/1.0.1). When v1.0.1 was originally created it did not change any of the public API of `1.0.0`, however it substantially changed the underlying files to warrant a `1.1.0` release.
