### PR TITLE
feat: add support for structured log info

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -821,6 +821,59 @@ components:
         outputs:
           type: object
           description: The outputs from the workflow run.
+    LogType:
+      title: LogType
+      enum:
+        - WRROC_PROCESS
+        - WRROC_WORKFLOW
+        - WRROC_PROV
+      type: string
+      nullable: true
+      description: >
+        Supported models and schemes for describing the shape of structured logging information. Can take any of the following values:
+
+        + WRROC_PROCESS: Expects a single string item in `StructuredLog.logs` that represents a valid Workflow Run RO-Crate Process Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/process_run_crate) of the version indicated in `StructuredLog.log_type_version`.
+
+        + WRROC_WORKFLOW: Expects a single string item in `StructuredLog.logs` that represents a valid Workflow Run RO-Crate Workflow Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate) of the version indicated in `StructuredLog.log_type_version`.
+
+        + WRROC_PROV: Expects a single string item in `StructuredLog.logs` that represents a valid Workflow Run RO-Crate Provenance Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate) of the version indicated in `StructuredLog.log_type_version`.
+
+        + null: Use if your preferred logging scheme is not explicitly supported. In that case, make sure to provide documentation for client implementations in `StructuredLog.doc_url`
+    StructuredLog:
+      title: StructuredLog
+      type: object
+      properties:
+        log_type:
+          $ref: '#/components/schemas/LogType'
+        log_type_version:
+          type: string
+          description: Version of `log_type` model or schema.
+        logs:
+          oneOf:
+            - type: string
+            - type: array
+              items: {}
+            - type: object
+          description: >-
+            Structured log message content. Whether one or more log messages are used and whether
+            these represent strings or more complex objects depends on the log type (see `spec_url`
+            and/or `doc_url` for additional details).
+        spec_url:
+          type: string
+          description: >-
+            A URL pointing to the specification describing the `log_type` model or schema. At least
+            one of `spec_url` and `doc_url` should always be provided if `log_type` is `null`.
+        doc_url:
+          type: string
+          description: >-
+            A web page URL with human-readable documentation for client implementers on how to
+            interpret `logs`. At least one of `spec_url` and `doc_url` should always be provided if
+            `log_type` is `null`.
+      required:
+        - log_type
+        - log_type_version
+        - logs
+      description: Log information whose shape is described by a defined model or schema.      
     Log:
       title: Log
       type: object
@@ -849,6 +902,11 @@ components:
           type: integer
           description: Exit code of the program
           format: int32
+        structured_logs:
+          type: array
+          items:
+            $ref: '#/components/schemas/StructuredLog'
+          description: Structured log information whose shape is described by one or more defined models or schemas.
         system_logs:
           type: array
           items:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -825,20 +825,24 @@ components:
       title: LogType
       enum:
         - WRROC_PROCESS
-        - WRROC_WORKFLOW
         - WRROC_PROV
+        - WRROC_WORKFLOW
       type: string
       nullable: true
       description: >
         Supported models and schemes for describing the shape of structured logging information. Can take any of the following values:
 
-        + WRROC_PROCESS: Workflow Run RO-Crate Process Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/process_run_crate). Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
+        + WRROC_PROCESS: Workflow Run RO-Crate Process Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/process_run_crate).
+        Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
 
-        + WRROC_WORKFLOW: Workflow Run RO-Crate Workflow Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate).  Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
+        + WRROC_PROV: Workflow Run RO-Crate Provenance Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate).
+        Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
 
-        + WRROC_PROV: Workflow Run RO-Crate Provenance Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate). Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
+        + WRROC_WORKFLOW: Workflow Run RO-Crate Workflow Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate).
+        Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
 
-        + null: Use if your preferred logging scheme is not explicitly supported. In that case, make sure to provide sufficient documentation for client implementers to parse the log information in the web page referred to by `StructuredLog.doc_url`.
+        + null: Use if your preferred logging scheme is not explicitly supported.
+        In that case, make sure to provide sufficient documentation for client implementers to parse the log information in the web page referred to by `StructuredLog.doc_url`.
     StructuredLog:
       title: StructuredLog
       type: object
@@ -875,7 +879,7 @@ components:
         - log_type
         - log_type_version
         - logs
-      description: Log information whose shape is described by a defined model or schema.      
+      description: Log information whose shape is described by a defined model or schema.
     Log:
       title: Log
       type: object

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -832,13 +832,13 @@ components:
       description: >
         Supported models and schemes for describing the shape of structured logging information. Can take any of the following values:
 
-        + WRROC_PROCESS: Expects a single string item in `StructuredLog.logs` that represents a valid Workflow Run RO-Crate Process Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/process_run_crate) of the version indicated in `StructuredLog.log_type_version`.
+        + WRROC_PROCESS: Workflow Run RO-Crate Process Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/process_run_crate). Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
 
-        + WRROC_WORKFLOW: Expects a single string item in `StructuredLog.logs` that represents a valid Workflow Run RO-Crate Workflow Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate) of the version indicated in `StructuredLog.log_type_version`.
+        + WRROC_WORKFLOW: Workflow Run RO-Crate Workflow Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate).  Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
 
-        + WRROC_PROV: Expects a single string item in `StructuredLog.logs` that represents a valid Workflow Run RO-Crate Provenance Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate) of the version indicated in `StructuredLog.log_type_version`.
+        + WRROC_PROV: Workflow Run RO-Crate Provenance Run Crate (https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate). Expects a single serialized JSON-LD string item in `StructuredLog.logs` that conforms to the profile version indicated in `StructuredLog.log_type_version`.
 
-        + null: Use if your preferred logging scheme is not explicitly supported. In that case, make sure to provide documentation for client implementations in `StructuredLog.doc_url`
+        + null: Use if your preferred logging scheme is not explicitly supported. In that case, make sure to provide sufficient documentation for client implementers to parse the log information in the web page referred to by `StructuredLog.doc_url`.
     StructuredLog:
       title: StructuredLog
       type: object
@@ -856,8 +856,10 @@ components:
             - type: object
           description: >-
             Structured log message content. Whether one or more log messages are used and whether
-            these represent strings or more complex objects depends on the log type (see `spec_url`
-            and/or `doc_url` for additional details).
+            these represent strings or more complex objects depends on the log type. Log messages
+            can also contain URLs that point to web sites that host the actual log contents. See
+            the `LogType` description and `spec_url` and/or `doc_url` for additional details on
+            how the contents of a given log format are mapped to this property.
         spec_url:
           type: string
           description: >-


### PR DESCRIPTION
## Implementation notes:

- Adds a `structured_logs` array property to the `Log` schema that allows implementers to provide well-defined structure log information for run (via `RunLog.run_log`) and task logs (via `RunLog.task_logs[]`).
- The `structured_logs` property uses a custom schema of type `StructuredLog` that defines a model or schema (`log_type`) of a given version (`log_type_version`) that describe the shape of the log contents (`logs`). Optional properties comprise pointers to additional information, in particular a URL to the specification of the model or schema itself (`spec_url`) and a URL to human-readable implementation notes (`doc_url`) describing how to consume the log contents.
- Valid values for `log_type` are defined in the `enum` `LogType` and their mapping to the log contents in `logs` should be sufficiently well described in the `enum` description such that server-side implementers can reasonably be expected to provide the logs in a uniform way, while client-side implementers can reasonably be expected to consume them as long as they provide support for the indicated `log_type_version`.
- The `enum` `LogType` is nullable. Specifying `null` can be used to provide information on structured log formats that are not (yet) explicitly supported by WES. In such cases, it is strongly advised that at least one of `spec_url` or `doc_url` are provided to allow clients to interpret the log concents.

## Open questions:

- Given that the proposed mechanism may also be relevant for TES, the `StructureLog` and `LogType` schemas could also be defined in a separate repository where schemas are kept that can be reused across multiple APIs (perhaps governed by the Cloud WS or DaMaSC?).
- While the `logs` property was defined in a deliberately promiscuous way (it can take a string, an object or an array of arbitrary values), it is not clear if the proposed schema is sufficient for supporting a wide range of external log format models and schemas.
- The proposed code adds the Workflow Run RO-Crate profile collection as known/defined structured log formats. This is motivated by an important use case for the ELIXIR Cloud & AAI Driver Project. Moreover, mapping the Workflow Run RO-Crate profile collection should be easy, given that RO-Crates are JSON-LD documents that should be relatively trivial to return as a single `string` item. However, if adding a set of concrete log formats goes too far at this point, these can also be added at a later point.
- OpenAPI 3.1 provides a way to annotate individual `enum` values via `oneOf` and `const` (see [here](https://stackoverflow.com/a/66471626/20831802)). Adopting this would greatly improve upon the maintainability of the `LogType` `enum`. However, it would require to upgrade WES to OpenAPI 3.1.

Resolves #215