### PR TITLE
docs: readd system state count description

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -632,6 +632,9 @@ components:
               additionalProperties:
                 type: integer
                 format: int64
+              description: >-
+                The system statistics, key is the statistic, value is the count of runs in that state.
+                See the State enum for the possible keys.
             auth_instructions_url:
               type: string
               description: A web page URL with human-readable instructions on how to get an authorization token for use with a specific WES endpoint.


### PR DESCRIPTION
Readd `system_state_count` description that got lost when migrating from Swagger/OpenAPI v2 to OpenAPI v3 between WES 1.0.0 and WES 1.0.1 (documents for both OpenAPI v2 and v3) / WES 1.1.0 (document for OpenAPI v2 dropped).

Fixes #221 