### PR TITLE
Structured parameters and outputs

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -10,7 +10,7 @@ info:
 
     ## Executive Summary
 
-    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (commonly [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, WES servers describe what they support via service-info) on multiple different platforms, clouds, and environments.
+    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (commonly [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [Snakemake](https://Snakemake.readthedocs.io/en/stable/) formatted workflows, WES servers describe what they support via service-info) on multiple different platforms, clouds, and environments.
 
     Key features of the API:
 
@@ -35,23 +35,23 @@ tags:
     description: Submit and monitor workflows in a WES environment
   - name: Introduction
     description: |
-      This document describes the WES API and provides details on the specific endpoints, request formats, and response.  It is intended to provide key information for developers of WES-compatible services as well as clients that will call these WES services.
+      This document describes the WES API and provides details on the specific endpoints, request formats, and responses.  It is intended to provide key information for developers of WES-compatible services as well as clients that will call these WES services.
 
       Use cases include:
       
-      - "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
-      - Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. Dockstore.org), and run them over their data
-      
+      - "Bring your code to the data": a researcher who has built their own custom analysis workflow can submit it to run on a dataset owned by an external organization, instead of having to download a copy of the data for local analysis.
+      - Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared repository (e.g. [Dockstore.org](https://dockstore.org)), and run them on their data
+
       ## Standards
         
-      The WES API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses and standard HTTP/HTTPS for information transport.
+      The WES API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses (where applicable) and standard HTTP/HTTPS for information transport.
   - name: Authorization & Authentication
     description: |
       Users must supply credentials that establish their identity and authorization in order to use a WES endpoint. We recommend that WES implementations use an OAuth2 [**bearer token**](https://oauth.net/2/bearer-tokens/), although they can choose other mechanisms if appropriate. WES callers can use the `auth_instructions_url` from the [**`service-info` endpoint**](https://ga4gh.github.io/workflow-execution-service-schemas/#/WorkflowExecutionService/GetServiceInfo) to learn how to obtain and use a bearer token for a particular implementation.
 
       The WES implementation is responsible for checking that a user is authorized to submit workflow run requests. The particular authorization policy is up to the WES implementer.
 
-      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the GA4GH Data Repository Service is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES.  This is a work in progress and support of DRS in WES will be added in a future release of WES.
+      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the [GA4GH Data Repository Service](https://ga4gh.github.io/data-repository-service-schemas/) is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES calls.  This is a work in progress and support of DRS in WES will be added in a future release of WES.
   - name: serviceinfo_model
     x-displayName: ServiceInfo
     description: |
@@ -150,7 +150,7 @@ paths:
       tags:
         - Service Info
       summary: GetServiceInfo
-      description: May include information related (but not limited to) the workflow descriptor formats, versions supported, the WES API versions supported, and information about general service availability.
+      description: Includes information related, but not limited to, the workflow descriptor formats, workflow engines, versions supported, the WES API versions supported, and information about general service availability and access.
       operationId: GetServiceInfo
       parameters: [ ]
       responses:
@@ -251,25 +251,25 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows.
+        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
 
         2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-ended string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
-        - **JSON requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
+        - **`application/json` requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
 
-        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
+        - **`multipart/form-data` requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
 
         - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
-        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or another alternative supported by this WES instance, see service-info)
+        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "Snakemake", or another alternative supported by this WES instance, see service-info)
 
         - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance
 
@@ -296,7 +296,7 @@ paths:
                   description: JSON-encoded unified workflow parameters (see RunRequest for how to encode)
                 workflow_type:
                   type: string
-                  description: Workflow descriptor type (CWL, WDL, Nextflow, SnakeMake, etc. see service-info for supported types)
+                  description: Workflow descriptor type must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
                 workflow_type_version:
                   type: string
                   description: The workflow descriptor type version, must be one supported by this WES instance
@@ -662,6 +662,10 @@ components:
               items:
                 type: string
               description: The filesystem protocols supported by this service, currently these may include common protocols using the terms 'http', 'https', 'sftp', 's3', 'gs', 'file', or 'synapse', but others  are possible and the terms beyond these core protocols are currently not fixed.   This section reports those protocols (either common or not) supported by this WES service.
+            workflow_engine:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/WorkflowEngine'
             workflow_engine_versions:
               type: object
               additionalProperties:
@@ -683,7 +687,7 @@ components:
               type: object
               additionalProperties:
                 type: string
-                description: A message containing useful information about the running service, including supported versions and default settings.
+                description: Tags containing useful information about the WES service.
           required:
             - workflow_type_versions
             - supported_wes_versions
@@ -883,7 +887,7 @@ components:
           description: >-
             REQUIRED
 
-            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "SnakeMake" currently (or another alternative supported by this WES instance)
+            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
         workflow_type_version:
           type: string
           description: >-
@@ -1040,7 +1044,7 @@ components:
           type: array
           items:
             type: string
-          description: an array of one or more acceptable types for the `workflow_type`
+          description: an array of one or more acceptable types for the `workflow_type`, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
       description: Available workflow types supported by a given instance of the service.
     TaskListResponse:
       title: TaskListResponse
@@ -1096,8 +1100,18 @@ components:
           type: array
           items:
             type: string
-          description: An array of one or more acceptable engines versions for the `workflow_engine`
+          description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as '<workflow_engine>_<version>' for clarity.
       description: Available workflow engine versions supported by a given instance of the service.
+  WorkflowEngine:
+      title: WorkflowEngine
+      type: object
+      properties:
+        workflow_engine:
+          type: array
+          items:
+            type: string
+          description: An array of one or more acceptable workflow engines. Since a server may support multiple engines and version, the recommendation is to encode the workflow_engine_version array as '<workflow_engine>_<version>' where workflow_engine values match this array for clarity.
+      description: Available workflow engines supported by a given instance of the service.
     RunListResponse:
       title: RunListResponse
       type: object
@@ -1160,7 +1174,7 @@ components:
               description: Workflow completion time in ISO 8601 format
             engine:
               type: string
-              description: Workflow engine used (cromwell, toil, cwltool, nextflow, snakemake)
+              description: Workflow engine used (cromwell, toil, cwltool, nextflow, Snakemake)
             engine_version:
               type: string
               description: Version of the workflow engine

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -10,14 +10,15 @@ info:
 
     ## Executive Summary
 
-    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (currently [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, other types may be supported in the future) on multiple different platforms, clouds, and environments.
+    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (commonly [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, WES servers describe what they support via service-info) on multiple different platforms, clouds, and environments.
 
     Key features of the API:
 
     - can request that a workflow be run
-    - can pass parameters to that workflow (e.g. input files, cmdline arguments) both workflow-type specific as well as a generalized parameter format
+    - can pass parameters to that workflow (e.g. input files, cmdline arguments) via both workflow-type specific parameter formats as well as a generalized parameter JSON format
     - can get information about running workflows (e.g. status, errors, output file locations)
     - can cancel a running workflow
+    - can retrieve logs and outputs file locations from a workflow run
 servers:
 - url: https://{defaultHost}/{basePath}/{apiVersion}
   variables:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -14,10 +14,10 @@ info:
 
     Key features of the API:
 
-    + can request that a workflow be run
-    + can pass parameters to that workflow (e.g. input files, cmdline arguments)
-    + can get information about running workflows (e.g. status, errors, output file locations)
-    + can cancel a running workflow
+    - can request that a workflow be run
+    - can pass parameters to that workflow (e.g. input files, cmdline arguments)
+    - can get information about running workflows (e.g. status, errors, output file locations)
+    - can cancel a running workflow
 servers:
 - url: https://{defaultHost}/{basePath}/{apiVersion}
   variables:
@@ -38,8 +38,8 @@ tags:
 
       Use cases include:
       
-      + "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
-      + Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. Dockstore.org), and run them over their data
+      - "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
+      - Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. Dockstore.org), and run them over their data
       
       ## Standards
         
@@ -235,7 +235,7 @@ paths:
       tags:
         - Workflow Runs
       summary: RunWorkflow
-      description: >-
+      description: |
         This endpoint creates a new workflow run and returns a `RunId` to monitor its progress.
 
         **Content Types Supported:**

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -4,7 +4,7 @@ info:
   contact: {}
   version: '1.2.0'
   x-logo:
-    url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
+    url: 'https://www.ga4gh.org/wp-content/themes/ga4gh/dist/assets/svg/logos/logo-full-color.svg'
   description: |
     *Run standard workflows on workflow execution platforms in a platform-agnostic way.*
 
@@ -262,7 +262,7 @@ paths:
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file used by the workflow engine.
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
 
         - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -5,7 +5,7 @@ info:
   version: '1.1.0'
   x-logo:
     url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
-  description: >
+  description: |
     *Run standard workflows on workflow execution platforms in a platform-agnostic way.*
 
     ## Executive Summary
@@ -15,14 +15,14 @@ info:
     Key features of the API:
 
     - can request that a workflow be run
-    - can pass parameters to that workflow (e.g. input files, cmdline arguments)
+    - can pass parameters to that workflow (e.g. input files, cmdline arguments) both workflow-type specific as well as a generalized parameter format
     - can get information about running workflows (e.g. status, errors, output file locations)
     - can cancel a running workflow
 servers:
 - url: https://{defaultHost}/{basePath}/{apiVersion}
   variables:
     defaultHost:
-      default: www.example.com
+      default: wes.example.com
     basePath:
       default: ga4gh/wes
     apiVersion:
@@ -45,12 +45,12 @@ tags:
         
       The WES API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses and standard HTTP/HTTPS for information transport.
   - name: Authorization & Authentication
-    description: >
+    description: |
       Users must supply credentials that establish their identity and authorization in order to use a WES endpoint. We recommend that WES implementations use an OAuth2 [**bearer token**](https://oauth.net/2/bearer-tokens/), although they can choose other mechanisms if appropriate. WES callers can use the `auth_instructions_url` from the [**`service-info` endpoint**](https://ga4gh.github.io/workflow-execution-service-schemas/#/WorkflowExecutionService/GetServiceInfo) to learn how to obtain and use a bearer token for a particular implementation.
 
       The WES implementation is responsible for checking that a user is authorized to submit workflow run requests. The particular authorization policy is up to the WES implementer.
 
-      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the Data Object Service is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES.  This is a work in progress and support of DOS in WES will be added in a future release of WES.
+      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the GA4GH Data Repository Service is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES.  This is a work in progress and support of DRS in WES will be added in a future release of WES.
   - name: serviceinfo_model
     x-displayName: ServiceInfo
     description: |
@@ -240,31 +240,31 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.
+        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is full schema validation and OpenAPI tooling support along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support multiple workflow file uploads directly, which may be required for multi-file workflows.
 
-        2. **`multipart/form-data`**: Legacy format for cases requiring file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the string encoded arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
-        - **JSON requests**: Files are referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata.
+        - **JSON requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
 
         - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security.
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format)
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language
+        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
-        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or other supported types)
+        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or another alternative supported by this WES instance, see service-info)
 
-        - `workflow_type_version`: Version of the workflow language supported by this WES instance
+        - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance
 
         - `workflow_url`: Absolute URL to workflow file, or relative path to uploaded attachment
 
-        See the `RunRequest` schema documentation for complete field descriptions and validation rules.
+        See the `RunRequest` schema documentation for complete field descriptions and validation rules when encoding as strings in the multipart/form-data request.
       operationId: RunWorkflow
       parameters: [ ]
       requestBody:
@@ -279,31 +279,31 @@ paths:
               properties:
                 workflow_params:
                   type: string
-                  description: JSON-encoded workflow parameters (alternative to using RunRequest model)
+                  description: JSON-encoded workflow parameters (see RunRequest for how to encode)
                 workflow_unified_params:
                   type: string
-                  description: JSON-encoded unified workflow parameters (alternative to using RunRequest model)
+                  description: JSON-encoded unified workflow parameters (see RunRequest for how to encode)
                 workflow_type:
                   type: string
-                  description: Workflow descriptor type (CWL, WDL, etc.)
+                  description: Workflow descriptor type (CWL, WDL, Nextflow, SnakeMake, etc. see service-info for supported types)
                 workflow_type_version:
                   type: string
-                  description: Version of the workflow descriptor type
+                  description: The workflow descriptor type version, must be one supported by this WES instance
                 tags:
                   type: string
-                  description: JSON-encoded key-value tags for the workflow run
+                  description: JSON-encoded key-value tags for the workflow run (see RunRequest for how to encode)
                 workflow_engine:
                   type: string
-                  description: Workflow engine to use
+                  description: The workflow engine, must be one supported by this WES instance. Required if workflow_engine_version is provided.
                 workflow_engine_version:
                   type: string
-                  description: Version of the workflow engine
+                  description: The workflow engine version, must be one supported by this WES instance. If workflow_engine is provided, but workflow_engine_version is not, servers can make no assumptions with regard to the engine version the WES instance uses to process the request if that WES instance supports multiple versions of the requested engine.
                 workflow_engine_parameters:
                   type: string
-                  description: JSON-encoded engine-specific parameters
+                  description: JSON-encoded engine-specific parameters (see RunRequest for how to encode)
                 workflow_url:
                   type: string
-                  description: URL to the workflow descriptor file
+                  description: The workflow document. When workflow_attachment is used to attach files, the workflow_url may be a relative path to one of the attachments.
                 workflow_attachment:
                   type: array
                   items:
@@ -701,7 +701,7 @@ components:
         - CANCELING
         - PREEMPTED
       type: string
-      description: >
+      description: |
         State can take any of the following values:
 
           + UNKNOWN: The state of the task is unknown. This provides a safe default for messages where this field is missing, for example, so that a missing field does not accidentally imply that the state is QUEUED.
@@ -869,7 +869,7 @@ components:
           description: >-
             REQUIRED
 
-            The workflow descriptor type, must be "CWL" or "WDL" currently (or another alternative supported by this WES instance)
+            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "SnakeMake" currently (or another alternative supported by this WES instance)
         workflow_type_version:
           type: string
           description: >-
@@ -899,7 +899,7 @@ components:
           description: >-
             REQUIRED
 
-            The workflow CWL or WDL document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
+            The workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
       description: >-
         To execute a workflow, send a run request including all the details needed to begin downloading
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -1065,7 +1065,7 @@ components:
           type: array
           items:
             type: string
-          description: an array of one or more acceptable type and versions for the `workflow_type`. Use the convension `<workflow_type>_<version>` to encode this array for clarity. For example, a WES service supporting CWL 1.0 and WDL 1.1 would encode this as `["CWL_1.0", "WDL_1.1"]`.
+          description: an array of one or more acceptable type and versions for the `workflow_type`. Use the convention `<workflow_type>_<version>` to encode this array for clarity. For example, a WES service supporting CWL 1.0 and WDL 1.1 would encode this as `["CWL_1.0", "WDL_1.1"]`.
       description: Available workflow type versions supported by a given instance of the service.
     TaskListResponse:
       title: TaskListResponse

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -251,9 +251,9 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
+        1. **`application/json`** (Recommended for workflows submitted by URLs): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
 
-        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-ended string arguments correctly (multipart form submissions only support strings hence the limitation). 
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-encoded string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
@@ -265,15 +265,15 @@ paths:
 
         - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a JSON string) used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field (and the recommended way to pass params). If provided, it takes precedence over `workflow_params`.
+        - **`workflow_unified_params`**: Universal parameter format that the WES server implementation converts to the target workflow language parameterization format.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified `workflow_type`.  This is an optional field (and the recommended way to pass params). If provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
         - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "Snakemake", or another alternative supported by this WES instance, see service-info)
 
-        - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance
+        - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance, see service-info
 
-        - `workflow_url`: Absolute URL to workflow file, or relative path to uploaded attachment
+        - `workflow_url`: Absolute URL to primary workflow file, or relative path to uploaded attachment
 
         See the `RunRequest` schema documentation for complete field descriptions and validation rules when encoding as strings in the multipart/form-data request.
       operationId: RunWorkflow
@@ -290,19 +290,19 @@ paths:
               properties:
                 workflow_params:
                   type: string
-                  description: JSON-encoded workflow parameters (see RunRequest for how to encode)
+                  description: JSON-encoded native workflow parameters (see RunRequest for how to encode)
                 workflow_unified_params:
                   type: string
-                  description: JSON-encoded unified workflow parameters (see RunRequest for how to encode)
+                  description: JSON-encoded universal workflow parameters (see RunRequest for how to encode)
                 workflow_type:
                   type: string
                   description: Workflow descriptor type must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
                 workflow_type_version:
                   type: string
-                  description: The workflow descriptor type version, must be one supported by this WES instance
+                  description: The workflow descriptor type version, must be one supported by this WES instance, see service-info
                 tags:
                   type: string
-                  description: JSON-encoded key-value tags for the workflow run (see RunRequest for how to encode)
+                  description: JSON-encoded object containing key-value tags for the workflow run (e.g., '{"experiment":"rna-seq","user":"john","sample_id":"SAMPLE_001"}')
                 workflow_engine:
                   type: string
                   description: The workflow engine, must be one supported by this WES instance. Required if workflow_engine_version is provided.
@@ -892,17 +892,21 @@ components:
           description: >-
             REQUIRED
 
-            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
+            Workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info for supported types)
         workflow_type_version:
           type: string
           description: >-
             REQUIRED
 
-            The workflow descriptor type version, must be one supported by this WES instance
+            The workflow descriptor type version, must be one supported by this WES instance (see service-info for supported versions)
         tags:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            OPTIONAL
+
+            Arbitrary key-value tags to associate with the workflow run for organization, tracking, or metadata purposes. Examples include experiment names, user identifiers, sample IDs, or project codes.
         workflow_engine_parameters:
           type: object
           additionalProperties:
@@ -910,19 +914,21 @@ components:
         workflow_engine:
           type: string
           description: >-
-            The workflow engine, must be one supported by this WES instance. Required if workflow_engine_version is provided.
+            OPTIONAL
+
+            The workflow engine, must be one supported by this WES instance (see service-info for supported engines). Required if workflow_engine_version is provided.
         workflow_engine_version:
           type: string
           description: >-
-            The workflow engine version, must be one supported by this WES instance.
-            If workflow_engine is provided, but workflow_engine_version is not, servers can make no assumptions with regard to the engine version the WES instance uses to process the request if 
-            that WES instance supports multiple versions of the requested engine.
+            OPTIONAL
+
+            The workflow engine version, must be one supported by this WES instance (see service-info for supported engine versions). If workflow_engine is provided, but workflow_engine_version is not, servers can make no assumptions with regard to the engine version the WES instance uses to process the request if that WES instance supports multiple versions of the requested engine.
         workflow_url:
           type: string
           description: >-
             REQUIRED
 
-            The workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
+            The primary workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments that is the primary workflow to be executed.
         additional_workflow_urls:
           type: array
           items:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Workflow Execution Service
   contact: {}
-  version: '1.1.0'
+  version: '1.2.0'
   x-logo:
     url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
   description: |
@@ -10,7 +10,7 @@ info:
 
     ## Executive Summary
 
-    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (currently [**CWL**](https://www.commonwl.org/) or [**WDL**](http://www.openwdl.org/) formatted workflows, other types may be supported in the future) on multiple different platforms, clouds, and environments.
+    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (currently [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, other types may be supported in the future) on multiple different platforms, clouds, and environments.
 
     Key features of the API:
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -742,9 +742,98 @@ components:
         workflow_params:
           type: object
           description: >-
-            REQUIRED
+            REQUIRED (unless workflow_unified_params provided)
 
             The workflow run parameterizations (JSON encoded), including input and output file locations
+        workflow_unified_params:
+          type: object
+          description: >-
+            OPTIONAL
+
+            Unified parameter format that can be converted to workflow-language-specific format.
+            If provided, takes precedence over workflow_params. WES implementations should
+            convert these to the appropriate native format for the specified workflow_type.
+          properties:
+            version:
+              type: string
+              description: Version of the unified parameter format
+              default: "1.0"
+            parameters:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum: ["String", "Integer", "Float", "Boolean", "File", "Directory", "Array", "Object"]
+                    description: Parameter type
+                  value:
+                    description: Parameter value (type depends on 'type' field)
+                  element_type:
+                    type: string
+                    description: For Array types, specifies the type of array elements
+                  file_metadata:
+                    type: object
+                    description: Optional metadata for File and Directory types
+                    properties:
+                      size:
+                        type: integer
+                        description: File size in bytes
+                        format: int64
+                      checksum:
+                        type: string
+                        description: File checksum in format 'algorithm:hash' (e.g., 'sha256:abc123...')
+                      secondary_files:
+                        type: array
+                        items:
+                          type: string
+                        description: Related files such as indexes or companion files
+                      format:
+                        type: string
+                        description: File format or MIME type
+                      last_modified:
+                        type: string
+                        description: Last modification time in ISO 8601 format
+                  description:
+                    type: string
+                    description: Human-readable parameter description
+                  optional:
+                    type: boolean
+                    default: false
+                    description: Whether this parameter is optional
+                  default:
+                    description: Default value if parameter not provided (type depends on 'type' field)
+                  constraints:
+                    type: object
+                    description: Validation constraints for the parameter value
+                    properties:
+                      min:
+                        description: Minimum value (for numeric types)
+                      max:
+                        description: Maximum value (for numeric types)
+                      min_length:
+                        type: integer
+                        description: Minimum length (for String types)
+                      max_length:
+                        type: integer
+                        description: Maximum length (for String types)
+                      pattern:
+                        type: string
+                        description: Regular expression pattern (for String types)
+                      enum:
+                        type: array
+                        items:
+                          description: Allowed value (type matches parameter type)
+                        description: List of allowed values
+                      min_items:
+                        type: integer
+                        description: Minimum number of items (for Array types)
+                      max_items:
+                        type: integer
+                        description: Maximum number of items (for Array types)
+                required:
+                  - type
+                  - value
         workflow_type:
           type: string
           description: >-

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -254,7 +254,7 @@ paths:
 
         - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
+        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -798,7 +798,7 @@ components:
             OPTIONAL
 
             The workflow run parameterizations (JSON encoded), including input and output file locations.
-            Either `workflow_params` or `workflow_unified_params` must be provided, but not both.
+            Either `workflow_params` or `workflow_unified_params` must be provided, `workflow_unified_params` takes precedence.
         workflow_unified_params:
           type: object
           description: >-

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -257,15 +257,15 @@ paths:
 
         **File Handling:**
 
-        - **`application/json` requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
+        - **`application/json` requests**: Workflow file is referenced by URL or path via `workflow_url` with additional workflow files specified by `additional_workflow_urls`. Use `workflow_unified_params` for generic workflow parameterization (recommended when possible) or `workflow_params` for JSON-string encoded native workflow params passing.
 
-        - **`multipart/form-data` requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
+        - **`multipart/form-data` requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.  Use `workflow_unified_params` for generic workflow parameterization (recommended when possible) or `workflow_params` for JSON-string encoded native workflow params passing.
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a JSON string) used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
+        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field (and the recommended way to pass params). If provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
@@ -649,6 +649,10 @@ components:
         - $ref: 'https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service'
         - type: object
           properties:
+            workflow_type:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/WorkflowType'
             workflow_type_versions:
               type: object
               additionalProperties:
@@ -1037,6 +1041,16 @@ components:
           type: string
           description: The stringified version of the default parameter. e.g. "2.45".
       description: A message that allows one to describe default parameters for a workflow engine.
+    WorkflowType:
+      title: WorkflowType
+      type: object
+      properties:
+        workflow_type:
+          type: array
+          items:
+            type: string
+          description: an array of one or more acceptable types for the `workflow_type`, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
+      description: Available workflow types supported by a given instance of the service.
     WorkflowTypeVersion:
       title: WorkflowTypeVersion
       type: object
@@ -1045,8 +1059,8 @@ components:
           type: array
           items:
             type: string
-          description: an array of one or more acceptable types for the `workflow_type`, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
-      description: Available workflow types supported by a given instance of the service.
+          description: an array of one or more acceptable type and versions for the `workflow_type`. Use the convension `<workflow_type>_<version>` to encode this array for clarity. For example, a WES service supporting CWL 1.0 and WDL 1.1 would encode this as `["CWL_1.0", "WDL_1.1"]`.
+      description: Available workflow type versions supported by a given instance of the service.
     TaskListResponse:
       title: TaskListResponse
       type: object
@@ -1101,7 +1115,7 @@ components:
           type: array
           items:
             type: string
-          description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as '<workflow_engine>_<version>' for clarity.
+          description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as `<workflow_engine>_<version>` for clarity.
       description: Available workflow engine versions supported by a given instance of the service.
     WorkflowEngine:
       title: WorkflowEngine
@@ -1111,7 +1125,7 @@ components:
           type: array
           items:
             type: string
-          description: An array of one or more acceptable workflow engines. Since a server may support multiple engines and version, the recommendation is to encode the workflow_engine_version array as '<workflow_engine>_<version>' where workflow_engine values match this array for clarity.
+          description: An array of one or more acceptable workflow engines. Since a server may support multiple engines and version, the recommendation is to encode the workflow_engine_version array as `<workflow_engine>_<version>` where `workflow_engine` values match this array for clarity.
       description: Available workflow engines supported by a given instance of the service.
     RunListResponse:
       title: RunListResponse

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -253,7 +253,7 @@ paths:
 
         1. **`application/json`** (Recommended for workflows submitted by URLs): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
 
-        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-encoded string arguments correctly (multipart form submissions only support strings hence the limitation). 
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formatting the JSON-encoded string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -1178,40 +1178,6 @@ components:
           description: Named workflow outputs with structured metadata
           additionalProperties:
             $ref: '#/components/schemas/OutputObject'
-        workflow_metadata:
-          type: object
-          description: Overall workflow execution metadata
-          properties:
-            execution_id:
-              type: string
-              description: Unique identifier for this workflow execution
-            status:
-              $ref: '#/components/schemas/State'
-            start_time:
-              type: string
-              description: Workflow start time in ISO 8601 format
-            end_time:
-              type: string
-              description: Workflow completion time in ISO 8601 format
-            engine:
-              type: string
-              description: Workflow engine used (cromwell, toil, cwltool, nextflow, Snakemake)
-            engine_version:
-              type: string
-              description: Version of the workflow engine
-            resource_usage:
-              type: object
-              description: Resource consumption statistics
-              properties:
-                cpu_hours:
-                  type: number
-                  description: Total CPU hours consumed
-                memory_gb_hours:
-                  type: number
-                  description: Total memory GB-hours consumed
-                disk_gb:
-                  type: number
-                  description: Total disk space used in GB
     OutputObject:
       title: OutputObject
       type: object

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -107,6 +107,14 @@ tags:
     x-displayName: WorkflowEngineVersion
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/WorkflowEngineVersion" />
+  - name: workflowoutputs_model
+    x-displayName: WorkflowOutputs
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/WorkflowOutputs" />
+  - name: outputobject_model
+    x-displayName: OutputObject
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/OutputObject" />
 x-tagGroups:
   - name: Overview
     tags:
@@ -133,6 +141,8 @@ x-tagGroups:
       - defaultworkflowengineparameter_model
       - workflowtypeversion_model
       - workflowengineversion_model
+      - workflowoutputs_model
+      - outputobject_model
 paths:
   /service-info:
     get:
@@ -939,7 +949,10 @@ components:
               specification (2.0.0)
         outputs:
           type: object
-          description: The outputs from the workflow run.
+          description: The outputs from the workflow run (legacy format)
+        structured_outputs:
+          $ref: '#/components/schemas/WorkflowOutputs'
+          description: Structured workflow outputs with rich metadata and type safety
     Log:
       title: Log
       type: object
@@ -1094,8 +1107,118 @@ components:
           description: The integer representing the HTTP status code (e.g. 200, 404).
           format: int32
       description: An object that can optionally include information about the error.
-
-
+    WorkflowOutputs:
+      title: WorkflowOutputs
+      type: object
+      description: Structured workflow outputs with rich metadata and provenance information
+      properties:
+        version:
+          type: string
+          description: Version of the structured outputs format
+          default: "1.0"
+        outputs:
+          type: object
+          description: Named workflow outputs with structured metadata
+          additionalProperties:
+            $ref: '#/components/schemas/OutputObject'
+        workflow_metadata:
+          type: object
+          description: Overall workflow execution metadata
+          properties:
+            execution_id:
+              type: string
+              description: Unique identifier for this workflow execution
+            status:
+              $ref: '#/components/schemas/State'
+            start_time:
+              type: string
+              description: Workflow start time in ISO 8601 format
+            end_time:
+              type: string
+              description: Workflow completion time in ISO 8601 format
+            engine:
+              type: string
+              description: Workflow engine used (cromwell, toil, cwltool, nextflow, snakemake)
+            engine_version:
+              type: string
+              description: Version of the workflow engine
+            resource_usage:
+              type: object
+              description: Resource consumption statistics
+              properties:
+                cpu_hours:
+                  type: number
+                  description: Total CPU hours consumed
+                memory_gb_hours:
+                  type: number
+                  description: Total memory GB-hours consumed
+                disk_gb:
+                  type: number
+                  description: Total disk space used in GB
+    OutputObject:
+      title: OutputObject
+      type: object
+      description: A structured output object with metadata and provenance information
+      properties:
+        class:
+          type: string
+          enum: ["File", "Directory", "Array", "String", "Integer", "Float", "Boolean"]
+          description: Type of the output object
+        value:
+          description: Output value (type depends on class field)
+        location:
+          type: string
+          description: Absolute path or URL to the output file/directory (for File/Directory class)
+        basename:
+          type: string
+          description: Filename without directory path (for File/Directory class)
+        size:
+          type: integer
+          format: int64
+          description: Size in bytes (for File/Directory class)
+        checksum:
+          type: string
+          description: File integrity hash in format 'algorithm:hash' (e.g., 'sha256:abc123...')
+        format:
+          type: string
+          description: MIME type or format identifier (e.g., EDAM ontology reference)
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputObject'
+          description: Array elements (for Array class)
+        metadata:
+          type: object
+          description: Additional metadata about the output
+          properties:
+            created:
+              type: string
+              description: Creation timestamp in ISO 8601 format
+            source_task:
+              type: string
+              description: Task/step that generated this output
+            task_id:
+              type: string
+              description: Unique identifier of the generating task
+            command:
+              type: array
+              items:
+                type: string
+              description: Command line that generated this output
+            description:
+              type: string
+              description: Human-readable description of the output
+        secondary_files:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputObject'
+          description: Associated files (e.g., index files, companion files)
+        contents:
+          type: string
+          description: File contents for small files (≤64 KiB)
+      required:
+        - class
+        - value
 
 
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -323,7 +323,8 @@ paths:
                   items:
                     type: string
                     format: binary
-                  description: Files to be staged for workflow execution.  You set the filename/path using the Content-Disposition header in the multipart form submission.  For example 'Content-Disposition: form-data; name="workflow_attachment"; filename="workflows/helper.wdl"'.  The files are staged to a temporary directory and can be referenced by relative path in the workflow_url.
+                  description: >-
+                    Files to be staged for workflow execution. You set the filename/path using the Content-Disposition header in the multipart form submission. For example 'Content-Disposition: form-data; name="workflow_attachment"; filename="workflows/helper.wdl"'. The files are staged to a temporary directory and can be referenced by relative path in the workflow_url.
               required:
                 - workflow_type
                 - workflow_type_version
@@ -1102,7 +1103,7 @@ components:
             type: string
           description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as '<workflow_engine>_<version>' for clarity.
       description: Available workflow engine versions supported by a given instance of the service.
-  WorkflowEngine:
+    WorkflowEngine:
       title: WorkflowEngine
       type: object
       properties:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -238,25 +238,40 @@ paths:
       description: >-
         This endpoint creates a new workflow run and returns a `RunId` to monitor its progress.
 
-        The `workflow_attachment` array may be used to upload files that are required to execute the workflow, including the primary workflow, tools imported by the workflow, other files referenced by the workflow, or files which are part of the input.  The implementation should stage these files to a temporary directory and execute the workflow from there. These parts must have a Content-Disposition header with a "filename" provided for each part.  Filenames may include subdirectories, but must not include references to parent directories with '..' -- implementations should guard against maliciously constructed filenames.
+        **Content Types Supported:**
 
-        The `workflow_url` is either an absolute URL to a workflow file that is accessible by the WES endpoint, or a relative URL corresponding to one of the files attached using `workflow_attachment`.
+        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.
 
-        The `workflow_params` JSON object specifies input parameters, such as input files.  The exact format of the JSON object depends on the conventions of the workflow language being used.  Input files should either be absolute URLs, or relative URLs corresponding to files uploaded using `workflow_attachment`.  The WES endpoint must understand and be able to access URLs supplied in the input.  This is implementation specific.
+        2. **`multipart/form-data`**: Legacy format for cases requiring file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.
 
-        The `workflow_type` is the type of workflow language and must be "CWL" or "WDL" currently (or another alternative  supported by this WES instance).
+        **File Handling:**
 
-        The `workflow_type_version` is the version of the workflow language submitted and must be one supported by this WES instance.
+        - **JSON requests**: Files are referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata.
 
-        The `workflow_engine` is the engine that supports the workflow_type and must be supported by this WES instance.
-      
-        The `workflow_engine_version` is the version of workflow engine and must be supported by this WES instance.
+        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security.
 
-        See the `RunRequest` documentation for details about other fields.
+        **Parameter Formats:**
+
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format)
+
+        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language
+
+        **Required Fields:**
+
+        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or other supported types)
+
+        - `workflow_type_version`: Version of the workflow language supported by this WES instance
+
+        - `workflow_url`: Absolute URL to workflow file, or relative path to uploaded attachment
+
+        See the `RunRequest` schema documentation for complete field descriptions and validation rules.
       operationId: RunWorkflow
       parameters: [ ]
       requestBody:
         content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunRequest'
           multipart/form-data:
             encoding: { }
             schema:
@@ -264,27 +279,42 @@ paths:
               properties:
                 workflow_params:
                   type: string
+                  description: JSON-encoded workflow parameters (alternative to using RunRequest model)
+                workflow_unified_params:
+                  type: string
+                  description: JSON-encoded unified workflow parameters (alternative to using RunRequest model)
                 workflow_type:
                   type: string
+                  description: Workflow descriptor type (CWL, WDL, etc.)
                 workflow_type_version:
                   type: string
+                  description: Version of the workflow descriptor type
                 tags:
                   type: string
+                  description: JSON-encoded key-value tags for the workflow run
                 workflow_engine:
                   type: string
+                  description: Workflow engine to use
                 workflow_engine_version:
                   type: string
+                  description: Version of the workflow engine
                 workflow_engine_parameters:
                   type: string
+                  description: JSON-encoded engine-specific parameters
                 workflow_url:
                   type: string
+                  description: URL to the workflow descriptor file
                 workflow_attachment:
                   type: array
                   items:
                     type: string
                     format: binary
-                  description: ''
-        required: false
+                  description: Files to be staged for workflow execution
+              required:
+                - workflow_type
+                - workflow_type_version
+                - workflow_url
+        required: true
       responses:
         200:
           description: ''

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -250,15 +250,15 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is full schema validation and OpenAPI tooling support along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support multiple workflow file uploads directly, which may be required for multi-file workflows.
+        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows.
 
-        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the string encoded arguments correctly (multipart form submissions only support strings hence the limitation). 
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-ended string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
         - **JSON requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
 
-        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security.
+        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
 
         **Parameter Formats:**
 
@@ -314,12 +314,15 @@ paths:
                 workflow_url:
                   type: string
                   description: The workflow document. When workflow_attachment is used to attach files, the workflow_url may be a relative path to one of the attachments.
+                additional_workflow_urls:
+                  type: string
+                  description: JSON-encoded array of additional workflow URLs (see RunRequest for how to encode)
                 workflow_attachment:
                   type: array
                   items:
                     type: string
                     format: binary
-                  description: Files to be staged for workflow execution
+                  description: Files to be staged for workflow execution.  You set the filename/path using the Content-Disposition header in the multipart form submission.  For example 'Content-Disposition: form-data; name="workflow_attachment"; filename="workflows/helper.wdl"'.  The files are staged to a temporary directory and can be referenced by relative path in the workflow_url.
               required:
                 - workflow_type
                 - workflow_type_version
@@ -910,6 +913,24 @@ components:
             REQUIRED
 
             The workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
+        additional_workflow_urls:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+                description: URL to the workflow file (absolute URL or relative to uploaded attachments)
+              filename:
+                type: string
+                description: Target filename, possibly including relative path, where this file should be placed e.g. 'workflows/helper.wdl'. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
+            required:
+              - url
+              - filename
+          description: >-
+            OPTIONAL
+
+            Additional workflow files required for execution (e.g., imported workflows, subworkflows, or dependencies). Each entry specifies both the source URL and target file path for precise file placement.
       description: >-
         To execute a workflow, send a run request including all the details needed to begin downloading
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -795,9 +795,10 @@ components:
         workflow_params:
           type: object
           description: >-
-            REQUIRED (unless workflow_unified_params provided)
+            OPTIONAL
 
-            The workflow run parameterizations (JSON encoded), including input and output file locations
+            The workflow run parameterizations (JSON encoded), including input and output file locations.
+            Either `workflow_params` or `workflow_unified_params` must be provided, but not both.
         workflow_unified_params:
           type: object
           description: >-


### PR DESCRIPTION
# Overview 

This pull request updates the Workflow Execution Service (WES) OpenAPI specification to enhance functionality in several key ways without creating breaking changes. Key changes include cleanup of our documentation, making workflow types and engines consistent in our requests/responses, creating a universal workflow parameterization passing structure (vs. relying on workflow engine specific formats), and creating a universal output format to collect outputs in a structured way regardless of workflow engine.  Claude Code was used to generate some of these changes.

**eLwazi-hosted GA4GH Hackathon**

The eLwazi hosted GA4GH hackathon 7/28-8/1 is working on this issue given the need by various groups attending the session.  For more info, see the [agenda](https://docs.google.com/document/d/1z-2Uj2R9-yLt1fTfohdUBg-kPFfxXpkWSCZz6NrACwY/edit?tab=t.0#heading=h.g7tx7vgfgncd). 

**Built Documentation**

The human-readable documentation: https://ga4gh.github.io/workflow-execution-service-schemas/preview/feature/issue-176-wes-params/docs/index.html

# More detailed description

- The major goal was to introduce a possible implementation of structured inputs and outputs for WES (issue #176)
- We wanted to do this in a non-breaking change… so this was added rather than replacing the current mechanisms (e.g. you can still use workflow_params to send a workflow-specific parameters file, you can still use multipart/form-data to upload workflow file(s) and send params).
- I added additional_workflow_urls which allows you to send multiple secondary workflow URLs beyond the primary workflow supplied by workflow_url
- In addition to multipart/form-data added the ability to submit a workflow (as workflow URLs) using application/json and a well-structured request defined in OpenAPI (rather than just strings as used in the multipart/form-data request)
- Cleaned up service-info, it was missing workflow_type and workflow_engine but these are required values when submitting a new workflow run
- Cleaned up various documentation
- Incremented version to 1.2.0
- Added 'structured_outputs' to GET /runs/{run_id} as a way of structuring outputs from a workflow in a universal way (vs. leaving it undefined as an 'outputs' object)

# Issues/questions for discussion

- For workflow_params, should this be just a string for the multipart?  Does it really need to be JSON-encoded?  That seems limiting if you're trying to pass YAML to a workflow engine…  
- Do we need "application/json" and "multipart/form-data"?  Could we get away with just "multipart/form-data"?  The problem with this is the OpenAPI is not well defined since everything is just "string".  And it hurts client generation and makes it more error prone to code against this and correctly encode request.  So there's value in having a application/json request to cleanly code against the OpenAPI for that.  But the cost of supporting two workflow run request types may be too much for implementers. 
- I noticed workflow_engine was missing from the service-info response and the workflow_engines_version array is ambiguous if this WES server supports multiple workflow engines.  So I added the former and also updated the docs to say <workflow_engine>_<workflow_engine_version> should be used for the workflow_engine_version array to make it clear when a WES server supports a variety of engines.
- Same issue for workflow_type and workflow_type_version
- I feel like both workflow_engine and workflow_type should actually be an object where we can have versions listed under each instead of two separate arrays.  But I didn't want to change this since it would be a breaking change.
- I'm not sure what "system_state_counts" in service-info is for but it's required… 
- Our list of workflow types is "CWL", "WDL", "Nextflow", or "Snakemake" (or another alternative supported by this WES instance, see service-info).  Do we want to use lowercase here (which would match supported_filesystem_protocols)?


### Specification Updates generated by Copilot:

#### Version and Logo Updates:
* Updated API version from `1.1.0` to `1.2.0`.
* Changed logo URL to reflect the latest GA4GH branding.

#### Workflow Types and Engines:
* Added support for new workflow types (`Nextflow`, `Snakemake`) in addition to `CWL` and `WDL`.
* Introduced `workflow_engine` and `workflow_engine_versions` properties to specify supported workflow engines and their versions. [[1]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804R670-R673) [[2]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804R652-R655)

#### Parameterization Enhancements:
* Added `workflow_unified_params` for universal parameter format, enabling generic parameterization across workflow types.
* Expanded descriptions for `workflow_params` and `workflow_unified_params` fields, clarifying their use cases.

### Documentation Improvements:

#### Endpoint Descriptions:
* Enhanced descriptions for `RunWorkflow` endpoint, detailing supported content types (`application/json`, `multipart/form-data`) and file handling mechanisms.
* Improved `GetServiceInfo` endpoint description to include workflow engines and additional service information.

#### Tags and Groups:
* Added new tags (`workflowoutputs_model`, `outputobject_model`) and grouped them under `x-tagGroups` for better organization. [[1]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804R111-R118) [[2]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804R145-R153)

### Schema Updates:

#### New Properties:
* Added `workflow_type` and `workflow_engine` objects to the schema for defining supported types and engines. [[1]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804R652-R655) [[2]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804R670-R673)

#### Clarifications:
* Updated descriptions for existing schema fields, ensuring consistency and clarity. [[1]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804L642-R695) [[2]](diffhunk://#diff-1f171071387eb98ede480c7beb336dec6aa0a03e48a4c7a726fc19830121d804L674-R727)

These updates make the WES API more versatile, user-friendly, and aligned with emerging standards in workflow execution.