### PR TITLE
Data Access Credentials

### DIFF
--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -10,7 +10,7 @@ info:
 
     ## Executive Summary
 
-    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (commonly [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, WES servers describe what they support via service-info) on multiple different platforms, clouds, and environments.
+    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (commonly [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [Snakemake](https://Snakemake.readthedocs.io/en/stable/) formatted workflows, WES servers describe what they support via service-info) on multiple different platforms, clouds, and environments.
 
     Key features of the API:
 
@@ -35,23 +35,23 @@ tags:
     description: Submit and monitor workflows in a WES environment
   - name: Introduction
     description: |
-      This document describes the WES API and provides details on the specific endpoints, request formats, and response.  It is intended to provide key information for developers of WES-compatible services as well as clients that will call these WES services.
+      This document describes the WES API and provides details on the specific endpoints, request formats, and responses.  It is intended to provide key information for developers of WES-compatible services as well as clients that will call these WES services.
 
       Use cases include:
       
-      - "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
-      - Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. Dockstore.org), and run them over their data
-      
+      - "Bring your code to the data": a researcher who has built their own custom analysis workflow can submit it to run on a dataset owned by an external organization, instead of having to download a copy of the data for local analysis.
+      - Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared repository (e.g. [Dockstore.org](https://dockstore.org)), and run them on their data
+
       ## Standards
         
-      The WES API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses and standard HTTP/HTTPS for information transport.
+      The WES API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses (where applicable) and standard HTTP/HTTPS for information transport.
   - name: Authorization & Authentication
     description: |
       Users must supply credentials that establish their identity and authorization in order to use a WES endpoint. We recommend that WES implementations use an OAuth2 [**bearer token**](https://oauth.net/2/bearer-tokens/), although they can choose other mechanisms if appropriate. WES callers can use the `auth_instructions_url` from the [**`service-info` endpoint**](https://ga4gh.github.io/workflow-execution-service-schemas/#/WorkflowExecutionService/GetServiceInfo) to learn how to obtain and use a bearer token for a particular implementation.
 
       The WES implementation is responsible for checking that a user is authorized to submit workflow run requests. The particular authorization policy is up to the WES implementer.
 
-      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the GA4GH Data Repository Service is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES.  This is a work in progress and support of DRS in WES will be added in a future release of WES.
+      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the [GA4GH Data Repository Service](https://ga4gh.github.io/data-repository-service-schemas/) is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES calls.  This is a work in progress and support of DRS in WES will be added in a future release of WES.
   - name: serviceinfo_model
     x-displayName: ServiceInfo
     description: |
@@ -150,7 +150,7 @@ paths:
       tags:
         - Service Info
       summary: GetServiceInfo
-      description: May include information related (but not limited to) the workflow descriptor formats, versions supported, the WES API versions supported, and information about general service availability.
+      description: Includes information related, but not limited to, the workflow descriptor formats, workflow engines, versions supported, the WES API versions supported, and information about general service availability and access.
       operationId: GetServiceInfo
       parameters: [ ]
       responses:
@@ -251,25 +251,25 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows.
+        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
 
         2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-ended string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
-        - **JSON requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
+        - **`application/json` requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
 
-        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
+        - **`multipart/form-data` requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
 
         - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
-        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or another alternative supported by this WES instance, see service-info)
+        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "Snakemake", or another alternative supported by this WES instance, see service-info)
 
         - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance
 
@@ -296,7 +296,7 @@ paths:
                   description: JSON-encoded unified workflow parameters (see RunRequest for how to encode)
                 workflow_type:
                   type: string
-                  description: Workflow descriptor type (CWL, WDL, Nextflow, SnakeMake, etc. see service-info for supported types)
+                  description: Workflow descriptor type must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
                 workflow_type_version:
                   type: string
                   description: The workflow descriptor type version, must be one supported by this WES instance
@@ -662,6 +662,10 @@ components:
               items:
                 type: string
               description: The filesystem protocols supported by this service, currently these may include common protocols using the terms 'http', 'https', 'sftp', 's3', 'gs', 'file', or 'synapse', but others  are possible and the terms beyond these core protocols are currently not fixed.   This section reports those protocols (either common or not) supported by this WES service.
+            workflow_engine:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/WorkflowEngine'
             workflow_engine_versions:
               type: object
               additionalProperties:
@@ -683,7 +687,7 @@ components:
               type: object
               additionalProperties:
                 type: string
-                description: A message containing useful information about the running service, including supported versions and default settings.
+                description: Tags containing useful information about the WES service.
           required:
             - workflow_type_versions
             - supported_wes_versions
@@ -883,7 +887,7 @@ components:
           description: >-
             REQUIRED
 
-            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "SnakeMake" currently (or another alternative supported by this WES instance)
+            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
         workflow_type_version:
           type: string
           description: >-
@@ -1040,7 +1044,7 @@ components:
           type: array
           items:
             type: string
-          description: an array of one or more acceptable types for the `workflow_type`
+          description: an array of one or more acceptable types for the `workflow_type`, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
       description: Available workflow types supported by a given instance of the service.
     TaskListResponse:
       title: TaskListResponse
@@ -1096,8 +1100,18 @@ components:
           type: array
           items:
             type: string
-          description: An array of one or more acceptable engines versions for the `workflow_engine`
+          description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as '<workflow_engine>_<version>' for clarity.
       description: Available workflow engine versions supported by a given instance of the service.
+  WorkflowEngine:
+      title: WorkflowEngine
+      type: object
+      properties:
+        workflow_engine:
+          type: array
+          items:
+            type: string
+          description: An array of one or more acceptable workflow engines. Since a server may support multiple engines and version, the recommendation is to encode the workflow_engine_version array as '<workflow_engine>_<version>' where workflow_engine values match this array for clarity.
+      description: Available workflow engines supported by a given instance of the service.
     RunListResponse:
       title: RunListResponse
       type: object
@@ -1160,7 +1174,7 @@ components:
               description: Workflow completion time in ISO 8601 format
             engine:
               type: string
-              description: Workflow engine used (cromwell, toil, cwltool, nextflow, snakemake)
+              description: Workflow engine used (cromwell, toil, cwltool, nextflow, Snakemake)
             engine_version:
               type: string
               description: Version of the workflow engine

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -1291,10 +1291,27 @@ components:
               specification (2.0.0)
         outputs:
           type: object
-          description: The outputs from the workflow run (legacy format)
+          description: >-
+            The outputs from the workflow run (legacy format). 
+            For outputs that require authentication to access (such as restricted files or directories), 
+            use the 'output_credentials' section of this response to obtain the necessary authentication 
+            credentials. The mapping between specific output files and credentials is implementation-specific 
+            for this legacy format - use 'structured_outputs' for explicit credential references.
         structured_outputs:
           $ref: '#/components/schemas/WorkflowOutputs'
           description: Structured workflow outputs with rich metadata and type safety
+        output_credentials:
+          type: object
+          description: >-
+            Named credentials required to access workflow output files and directories. 
+            Each credential is identified by a unique key and can be referenced by multiple 
+            outputs via their 'credential_id' field. These credentials allow clients to 
+            authenticate and authorize access to restricted output resources.
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/PassportCredential'
+              - $ref: '#/components/schemas/BearerTokenCredential'
+              - $ref: '#/components/schemas/ApiKeyCredential'
     Log:
       title: Log
       type: object
@@ -1544,6 +1561,9 @@ components:
         contents:
           type: string
           description: File contents for small files (≤64 KiB)
+        credential_id:
+          type: string
+          description: Reference to a credential ID defined in the 'output_credentials' section of the RunLog response. This credential is required to authenticate and authorize access to this File or Directory output resource.
       required:
         - class
         - value

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -343,6 +343,7 @@ paths:
         required: true
       security:
         - BearerAuth: []
+        - PassportAuth: []
         - {}
       responses:
         200:
@@ -444,6 +445,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - PassportAuth: []
+        - {}
       requestBody:
         required: true
         content:
@@ -548,6 +552,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - PassportAuth: []
+        - {}
       requestBody:
         required: true
         content:
@@ -682,6 +689,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - PassportAuth: []
+        - {}
       requestBody:
         required: true
         content:
@@ -801,6 +811,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - PassportAuth: []
+        - {}
       requestBody:
         required: true
         content:
@@ -857,6 +870,7 @@ paths:
             type: string
       security:
         - BearerAuth: []
+        - PassportAuth: []
         - {}
       responses:
         200:
@@ -898,6 +912,13 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: Standard OAuth2 bearer token authentication
+    PassportAuth:
+      type: http
+      scheme: bearer
+      x-in: body
+      bearerFormat: JWT
+      description:
+        A valid GA4GH Passport must be passed in the body of an HTTP POST request as a passports[] array.
   schemas:
     ServiceInfo:
       title: ServiceInfo

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -10,14 +10,15 @@ info:
 
     ## Executive Summary
 
-    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (currently [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, other types may be supported in the future) on multiple different platforms, clouds, and environments.
+    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (commonly [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, WES servers describe what they support via service-info) on multiple different platforms, clouds, and environments.
 
     Key features of the API:
 
     - can request that a workflow be run
-    - can pass parameters to that workflow (e.g. input files, cmdline arguments) both workflow-type specific as well as a generalized parameter format
+    - can pass parameters to that workflow (e.g. input files, cmdline arguments) via both workflow-type specific parameter formats as well as a generalized parameter JSON format
     - can get information about running workflows (e.g. status, errors, output file locations)
     - can cancel a running workflow
+    - can retrieve logs and outputs file locations from a workflow run
 servers:
 - url: https://{defaultHost}/{basePath}/{apiVersion}
   variables:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -14,10 +14,10 @@ info:
 
     Key features of the API:
 
-    + can request that a workflow be run
-    + can pass parameters to that workflow (e.g. input files, cmdline arguments)
-    + can get information about running workflows (e.g. status, errors, output file locations)
-    + can cancel a running workflow
+    - can request that a workflow be run
+    - can pass parameters to that workflow (e.g. input files, cmdline arguments)
+    - can get information about running workflows (e.g. status, errors, output file locations)
+    - can cancel a running workflow
 servers:
 - url: https://{defaultHost}/{basePath}/{apiVersion}
   variables:
@@ -38,8 +38,8 @@ tags:
 
       Use cases include:
       
-      + "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
-      + Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. Dockstore.org), and run them over their data
+      - "Bring your code to the data": a researcher who has built their own custom analysis can submit it to run on a dataset owned by an external organization, instead of having to make a copy of the data
+      - Best-practices pipelines: a researcher who maintains their own controlled data environment can find useful workflows in a shared directory (e.g. Dockstore.org), and run them over their data
       
       ## Standards
         
@@ -235,7 +235,7 @@ paths:
       tags:
         - Workflow Runs
       summary: RunWorkflow
-      description: >-
+      description: |
         This endpoint creates a new workflow run and returns a `RunId` to monitor its progress.
 
         **Content Types Supported:**

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -4,7 +4,7 @@ info:
   contact: {}
   version: '1.2.0'
   x-logo:
-    url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
+    url: 'https://www.ga4gh.org/wp-content/themes/ga4gh/dist/assets/svg/logos/logo-full-color.svg'
   description: |
     *Run standard workflows on workflow execution platforms in a platform-agnostic way.*
 
@@ -262,7 +262,7 @@ paths:
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file used by the workflow engine.
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
 
         - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -5,7 +5,7 @@ info:
   version: '1.1.0'
   x-logo:
     url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
-  description: >
+  description: |
     *Run standard workflows on workflow execution platforms in a platform-agnostic way.*
 
     ## Executive Summary
@@ -15,14 +15,14 @@ info:
     Key features of the API:
 
     - can request that a workflow be run
-    - can pass parameters to that workflow (e.g. input files, cmdline arguments)
+    - can pass parameters to that workflow (e.g. input files, cmdline arguments) both workflow-type specific as well as a generalized parameter format
     - can get information about running workflows (e.g. status, errors, output file locations)
     - can cancel a running workflow
 servers:
 - url: https://{defaultHost}/{basePath}/{apiVersion}
   variables:
     defaultHost:
-      default: www.example.com
+      default: wes.example.com
     basePath:
       default: ga4gh/wes
     apiVersion:
@@ -45,12 +45,12 @@ tags:
         
       The WES API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses and standard HTTP/HTTPS for information transport.
   - name: Authorization & Authentication
-    description: >
+    description: |
       Users must supply credentials that establish their identity and authorization in order to use a WES endpoint. We recommend that WES implementations use an OAuth2 [**bearer token**](https://oauth.net/2/bearer-tokens/), although they can choose other mechanisms if appropriate. WES callers can use the `auth_instructions_url` from the [**`service-info` endpoint**](https://ga4gh.github.io/workflow-execution-service-schemas/#/WorkflowExecutionService/GetServiceInfo) to learn how to obtain and use a bearer token for a particular implementation.
 
       The WES implementation is responsible for checking that a user is authorized to submit workflow run requests. The particular authorization policy is up to the WES implementer.
 
-      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the Data Object Service is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES.  This is a work in progress and support of DOS in WES will be added in a future release of WES.
+      Systems like WES need to also address the ability to pass credentials with jobs for input and output access.  In the current version of WES, the passing of credentials to authenticate and authorize access to inputs and outputs, as well as mandates about necessary file transfer protocols to support, are out of scope.  However, parallel work on the GA4GH Data Repository Service is addressing ways to pass around access credentials with data object references, opening up the possibility that a future version of WES will provide concrete mechanisms for workflow runs to access data using credentials different than those used for WES.  This is a work in progress and support of DRS in WES will be added in a future release of WES.
   - name: serviceinfo_model
     x-displayName: ServiceInfo
     description: |
@@ -240,31 +240,31 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.
+        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is full schema validation and OpenAPI tooling support along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support multiple workflow file uploads directly, which may be required for multi-file workflows.
 
-        2. **`multipart/form-data`**: Legacy format for cases requiring file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the string encoded arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
-        - **JSON requests**: Files are referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata.
+        - **JSON requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
 
         - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security.
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format)
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language
+        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
-        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or other supported types)
+        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or another alternative supported by this WES instance, see service-info)
 
-        - `workflow_type_version`: Version of the workflow language supported by this WES instance
+        - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance
 
         - `workflow_url`: Absolute URL to workflow file, or relative path to uploaded attachment
 
-        See the `RunRequest` schema documentation for complete field descriptions and validation rules.
+        See the `RunRequest` schema documentation for complete field descriptions and validation rules when encoding as strings in the multipart/form-data request.
       operationId: RunWorkflow
       parameters: [ ]
       requestBody:
@@ -279,31 +279,31 @@ paths:
               properties:
                 workflow_params:
                   type: string
-                  description: JSON-encoded workflow parameters (alternative to using RunRequest model)
+                  description: JSON-encoded workflow parameters (see RunRequest for how to encode)
                 workflow_unified_params:
                   type: string
-                  description: JSON-encoded unified workflow parameters (alternative to using RunRequest model)
+                  description: JSON-encoded unified workflow parameters (see RunRequest for how to encode)
                 workflow_type:
                   type: string
-                  description: Workflow descriptor type (CWL, WDL, etc.)
+                  description: Workflow descriptor type (CWL, WDL, Nextflow, SnakeMake, etc. see service-info for supported types)
                 workflow_type_version:
                   type: string
-                  description: Version of the workflow descriptor type
+                  description: The workflow descriptor type version, must be one supported by this WES instance
                 tags:
                   type: string
-                  description: JSON-encoded key-value tags for the workflow run
+                  description: JSON-encoded key-value tags for the workflow run (see RunRequest for how to encode)
                 workflow_engine:
                   type: string
-                  description: Workflow engine to use
+                  description: The workflow engine, must be one supported by this WES instance. Required if workflow_engine_version is provided.
                 workflow_engine_version:
                   type: string
-                  description: Version of the workflow engine
+                  description: The workflow engine version, must be one supported by this WES instance. If workflow_engine is provided, but workflow_engine_version is not, servers can make no assumptions with regard to the engine version the WES instance uses to process the request if that WES instance supports multiple versions of the requested engine.
                 workflow_engine_parameters:
                   type: string
-                  description: JSON-encoded engine-specific parameters
+                  description: JSON-encoded engine-specific parameters (see RunRequest for how to encode)
                 workflow_url:
                   type: string
-                  description: URL to the workflow descriptor file
+                  description: The workflow document. When workflow_attachment is used to attach files, the workflow_url may be a relative path to one of the attachments.
                 workflow_attachment:
                   type: array
                   items:
@@ -701,7 +701,7 @@ components:
         - CANCELING
         - PREEMPTED
       type: string
-      description: >
+      description: |
         State can take any of the following values:
 
           + UNKNOWN: The state of the task is unknown. This provides a safe default for messages where this field is missing, for example, so that a missing field does not accidentally imply that the state is QUEUED.
@@ -869,7 +869,7 @@ components:
           description: >-
             REQUIRED
 
-            The workflow descriptor type, must be "CWL" or "WDL" currently (or another alternative supported by this WES instance)
+            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "SnakeMake" currently (or another alternative supported by this WES instance)
         workflow_type_version:
           type: string
           description: >-
@@ -899,7 +899,7 @@ components:
           description: >-
             REQUIRED
 
-            The workflow CWL or WDL document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
+            The workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
       description: >-
         To execute a workflow, send a run request including all the details needed to begin downloading
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -1065,7 +1065,7 @@ components:
           type: array
           items:
             type: string
-          description: an array of one or more acceptable type and versions for the `workflow_type`. Use the convension `<workflow_type>_<version>` to encode this array for clarity. For example, a WES service supporting CWL 1.0 and WDL 1.1 would encode this as `["CWL_1.0", "WDL_1.1"]`.
+          description: an array of one or more acceptable type and versions for the `workflow_type`. Use the convention `<workflow_type>_<version>` to encode this array for clarity. For example, a WES service supporting CWL 1.0 and WDL 1.1 would encode this as `["CWL_1.0", "WDL_1.1"]`.
       description: Available workflow type versions supported by a given instance of the service.
     TaskListResponse:
       title: TaskListResponse

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -251,9 +251,9 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
+        1. **`application/json`** (Recommended for workflows submitted by URLs): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
 
-        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-ended string arguments correctly (multipart form submissions only support strings hence the limitation). 
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-encoded string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
@@ -265,15 +265,15 @@ paths:
 
         - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a JSON string) used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field (and the recommended way to pass params). If provided, it takes precedence over `workflow_params`.
+        - **`workflow_unified_params`**: Universal parameter format that the WES server implementation converts to the target workflow language parameterization format.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified `workflow_type`.  This is an optional field (and the recommended way to pass params). If provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
         - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "Snakemake", or another alternative supported by this WES instance, see service-info)
 
-        - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance
+        - `workflow_type_version`: The workflow descriptor type version, must be one supported by this WES instance, see service-info
 
-        - `workflow_url`: Absolute URL to workflow file, or relative path to uploaded attachment
+        - `workflow_url`: Absolute URL to primary workflow file, or relative path to uploaded attachment
 
         See the `RunRequest` schema documentation for complete field descriptions and validation rules when encoding as strings in the multipart/form-data request.
       operationId: RunWorkflow
@@ -290,19 +290,19 @@ paths:
               properties:
                 workflow_params:
                   type: string
-                  description: JSON-encoded workflow parameters (see RunRequest for how to encode)
+                  description: JSON-encoded native workflow parameters (see RunRequest for how to encode)
                 workflow_unified_params:
                   type: string
-                  description: JSON-encoded unified workflow parameters (see RunRequest for how to encode)
+                  description: JSON-encoded universal workflow parameters (see RunRequest for how to encode)
                 workflow_type:
                   type: string
                   description: Workflow descriptor type must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
                 workflow_type_version:
                   type: string
-                  description: The workflow descriptor type version, must be one supported by this WES instance
+                  description: The workflow descriptor type version, must be one supported by this WES instance, see service-info
                 tags:
                   type: string
-                  description: JSON-encoded key-value tags for the workflow run (see RunRequest for how to encode)
+                  description: JSON-encoded object containing key-value tags for the workflow run (e.g., '{"experiment":"rna-seq","user":"john","sample_id":"SAMPLE_001"}')
                 workflow_engine:
                   type: string
                   description: The workflow engine, must be one supported by this WES instance. Required if workflow_engine_version is provided.
@@ -892,17 +892,21 @@ components:
           description: >-
             REQUIRED
 
-            The workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
+            Workflow descriptor type, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info for supported types)
         workflow_type_version:
           type: string
           description: >-
             REQUIRED
 
-            The workflow descriptor type version, must be one supported by this WES instance
+            The workflow descriptor type version, must be one supported by this WES instance (see service-info for supported versions)
         tags:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            OPTIONAL
+
+            Arbitrary key-value tags to associate with the workflow run for organization, tracking, or metadata purposes. Examples include experiment names, user identifiers, sample IDs, or project codes.
         workflow_engine_parameters:
           type: object
           additionalProperties:
@@ -910,19 +914,21 @@ components:
         workflow_engine:
           type: string
           description: >-
-            The workflow engine, must be one supported by this WES instance. Required if workflow_engine_version is provided.
+            OPTIONAL
+
+            The workflow engine, must be one supported by this WES instance (see service-info for supported engines). Required if workflow_engine_version is provided.
         workflow_engine_version:
           type: string
           description: >-
-            The workflow engine version, must be one supported by this WES instance.
-            If workflow_engine is provided, but workflow_engine_version is not, servers can make no assumptions with regard to the engine version the WES instance uses to process the request if 
-            that WES instance supports multiple versions of the requested engine.
+            OPTIONAL
+
+            The workflow engine version, must be one supported by this WES instance (see service-info for supported engine versions). If workflow_engine is provided, but workflow_engine_version is not, servers can make no assumptions with regard to the engine version the WES instance uses to process the request if that WES instance supports multiple versions of the requested engine.
         workflow_url:
           type: string
           description: >-
             REQUIRED
 
-            The workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
+            The primary workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments that is the primary workflow to be executed.
         additional_workflow_urls:
           type: array
           items:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Workflow Execution Service
   contact: {}
-  version: '1.1.0'
+  version: '1.2.0'
   x-logo:
     url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
   description: |
@@ -10,7 +10,7 @@ info:
 
     ## Executive Summary
 
-    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (currently [**CWL**](https://www.commonwl.org/) or [**WDL**](http://www.openwdl.org/) formatted workflows, other types may be supported in the future) on multiple different platforms, clouds, and environments.
+    The Workflow Execution Service (WES) API provides a standard way for users to submit workflow requests to workflow execution systems, and to monitor their execution. This API lets users run a single workflow (currently [CWL](https://www.commonwl.org/), [WDL](http://www.openwdl.org/), [Nextflow](https://www.nextflow.io/), and [SnakeMake](https://snakemake.readthedocs.io/en/stable/) formatted workflows, other types may be supported in the future) on multiple different platforms, clouds, and environments.
 
     Key features of the API:
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -742,9 +742,98 @@ components:
         workflow_params:
           type: object
           description: >-
-            REQUIRED
+            REQUIRED (unless workflow_unified_params provided)
 
             The workflow run parameterizations (JSON encoded), including input and output file locations
+        workflow_unified_params:
+          type: object
+          description: >-
+            OPTIONAL
+
+            Unified parameter format that can be converted to workflow-language-specific format.
+            If provided, takes precedence over workflow_params. WES implementations should
+            convert these to the appropriate native format for the specified workflow_type.
+          properties:
+            version:
+              type: string
+              description: Version of the unified parameter format
+              default: "1.0"
+            parameters:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum: ["String", "Integer", "Float", "Boolean", "File", "Directory", "Array", "Object"]
+                    description: Parameter type
+                  value:
+                    description: Parameter value (type depends on 'type' field)
+                  element_type:
+                    type: string
+                    description: For Array types, specifies the type of array elements
+                  file_metadata:
+                    type: object
+                    description: Optional metadata for File and Directory types
+                    properties:
+                      size:
+                        type: integer
+                        description: File size in bytes
+                        format: int64
+                      checksum:
+                        type: string
+                        description: File checksum in format 'algorithm:hash' (e.g., 'sha256:abc123...')
+                      secondary_files:
+                        type: array
+                        items:
+                          type: string
+                        description: Related files such as indexes or companion files
+                      format:
+                        type: string
+                        description: File format or MIME type
+                      last_modified:
+                        type: string
+                        description: Last modification time in ISO 8601 format
+                  description:
+                    type: string
+                    description: Human-readable parameter description
+                  optional:
+                    type: boolean
+                    default: false
+                    description: Whether this parameter is optional
+                  default:
+                    description: Default value if parameter not provided (type depends on 'type' field)
+                  constraints:
+                    type: object
+                    description: Validation constraints for the parameter value
+                    properties:
+                      min:
+                        description: Minimum value (for numeric types)
+                      max:
+                        description: Maximum value (for numeric types)
+                      min_length:
+                        type: integer
+                        description: Minimum length (for String types)
+                      max_length:
+                        type: integer
+                        description: Maximum length (for String types)
+                      pattern:
+                        type: string
+                        description: Regular expression pattern (for String types)
+                      enum:
+                        type: array
+                        items:
+                          description: Allowed value (type matches parameter type)
+                        description: List of allowed values
+                      min_items:
+                        type: integer
+                        description: Minimum number of items (for Array types)
+                      max_items:
+                        type: integer
+                        description: Maximum number of items (for Array types)
+                required:
+                  - type
+                  - value
         workflow_type:
           type: string
           description: >-

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -254,7 +254,7 @@ paths:
 
         - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format).  This field is used to send the native parameterization file used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
+        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -798,7 +798,7 @@ components:
             OPTIONAL
 
             The workflow run parameterizations (JSON encoded), including input and output file locations.
-            Either `workflow_params` or `workflow_unified_params` must be provided, but not both.
+            Either `workflow_params` or `workflow_unified_params` must be provided, `workflow_unified_params` takes precedence.
         workflow_unified_params:
           type: object
           description: >-

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -257,15 +257,15 @@ paths:
 
         **File Handling:**
 
-        - **`application/json` requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
+        - **`application/json` requests**: Workflow file is referenced by URL or path via `workflow_url` with additional workflow files specified by `additional_workflow_urls`. Use `workflow_unified_params` for generic workflow parameterization (recommended when possible) or `workflow_params` for JSON-string encoded native workflow params passing.
 
-        - **`multipart/form-data` requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
+        - **`multipart/form-data` requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.  Use `workflow_unified_params` for generic workflow parameterization (recommended when possible) or `workflow_params` for JSON-string encoded native workflow params passing.
 
         **Parameter Formats:**
 
-        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a string) used by the workflow engine.
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, Snakemake format).  This field is used to send the native parameterization file (encoded as a JSON string) used by the workflow engine.
 
-        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field, but if provided, it takes precedence over `workflow_params`.
+        - **`workflow_unified_params`**: Universal parameter format that WES server implementation converts to the target workflow language.  This allows for a more generic way to pass parameters that can be converted to the appropriate native format for the specified workflow_type.  This is an optional field (and the recommended way to pass params). If provided, it takes precedence over `workflow_params`.
 
         **Required Fields:**
 
@@ -649,6 +649,10 @@ components:
         - $ref: 'https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service'
         - type: object
           properties:
+            workflow_type:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/WorkflowType'
             workflow_type_versions:
               type: object
               additionalProperties:
@@ -1037,6 +1041,16 @@ components:
           type: string
           description: The stringified version of the default parameter. e.g. "2.45".
       description: A message that allows one to describe default parameters for a workflow engine.
+    WorkflowType:
+      title: WorkflowType
+      type: object
+      properties:
+        workflow_type:
+          type: array
+          items:
+            type: string
+          description: an array of one or more acceptable types for the `workflow_type`, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
+      description: Available workflow types supported by a given instance of the service.
     WorkflowTypeVersion:
       title: WorkflowTypeVersion
       type: object
@@ -1045,8 +1059,8 @@ components:
           type: array
           items:
             type: string
-          description: an array of one or more acceptable types for the `workflow_type`, must be "CWL", "WDL", "Nextflow", or "Snakemake" currently (or another alternative supported by this WES instance, see service-info)
-      description: Available workflow types supported by a given instance of the service.
+          description: an array of one or more acceptable type and versions for the `workflow_type`. Use the convension `<workflow_type>_<version>` to encode this array for clarity. For example, a WES service supporting CWL 1.0 and WDL 1.1 would encode this as `["CWL_1.0", "WDL_1.1"]`.
+      description: Available workflow type versions supported by a given instance of the service.
     TaskListResponse:
       title: TaskListResponse
       type: object
@@ -1101,7 +1115,7 @@ components:
           type: array
           items:
             type: string
-          description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as '<workflow_engine>_<version>' for clarity.
+          description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as `<workflow_engine>_<version>` for clarity.
       description: Available workflow engine versions supported by a given instance of the service.
     WorkflowEngine:
       title: WorkflowEngine
@@ -1111,7 +1125,7 @@ components:
           type: array
           items:
             type: string
-          description: An array of one or more acceptable workflow engines. Since a server may support multiple engines and version, the recommendation is to encode the workflow_engine_version array as '<workflow_engine>_<version>' where workflow_engine values match this array for clarity.
+          description: An array of one or more acceptable workflow engines. Since a server may support multiple engines and version, the recommendation is to encode the workflow_engine_version array as `<workflow_engine>_<version>` where `workflow_engine` values match this array for clarity.
       description: Available workflow engines supported by a given instance of the service.
     RunListResponse:
       title: RunListResponse

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -868,6 +868,7 @@ paths:
           style: simple
           schema:
             type: string
+        - $ref: '#/components/parameters/PassportRequestNotRequired'
       security:
         - BearerAuth: []
         - PassportAuth: []
@@ -1064,7 +1065,7 @@ components:
     PassportRunRequest:
       title: PassportRunRequest
       allOf:
-        - $ref: '#/components/schemas/PassportRequest'
+        - $ref: '#/components/schemas/PassportRequestNotRequired'
         - $ref: '#/components/schemas/RunRequest'
     RunRequest:
       title: RunRequest
@@ -1527,6 +1528,12 @@ components:
         - value
     PassportRequest:
       title: PassportRequest
+      allOf:
+        - $ref: '#/components/schemas/PassportRequestNotRequired'
+      required:
+        - passport
+    PassportRequestNotRequired:
+      title: PassportRequestNotRequired
       type: object
       description: Request object for GA4GH passport-based authentication
       properties:
@@ -1537,8 +1544,6 @@ components:
             format: jwt
           description: Array of GA4GH passport JWTs for authentication and authorization
           minItems: 1
-      required:
-        - passport
     RunsListRequest:
       title: RunsListRequest
       type: object

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -870,7 +870,8 @@ paths:
           style: simple
           schema:
             type: string
-        - $ref: '#/components/parameters/PassportRequestNotRequired'
+        - name: passport
+          $ref: '#/components/parameters/PassportRequestNotRequired'
       security:
         - BearerAuth: []
         - PassportAuth: []

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -292,7 +292,7 @@ paths:
           application/json:
             schema:
               oneOf:
-                - $ref: '#/components/schemas/RunRequest'
+                - $ref: '#/components/schemas/PassportRunRequest'
                 - $ref: '#/components/schemas/RunsListRequest'
           multipart/form-data:
             encoding: { }
@@ -1061,6 +1061,11 @@ components:
           required:
             - tags
       description: Small description of a workflow run
+    PassportRunRequest:
+      title: PassportRunRequest
+      allOf:
+        - $ref: '#/components/schemas/PassportRequest'
+        - $ref: '#/components/schemas/RunRequest'
     RunRequest:
       title: RunRequest
       type: object

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -870,8 +870,12 @@ paths:
           style: simple
           schema:
             type: string
-        - name: passport
-          $ref: '#/components/parameters/PassportRequestNotRequired'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequestNotRequired'
       security:
         - BearerAuth: []
         - PassportAuth: []

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -209,6 +209,9 @@ paths:
           explode: true
           schema:
             type: string
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -282,7 +285,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RunRequest'
+              oneOf:
+                - $ref: '#/components/schemas/RunRequest'
+                - allOf:
+                    - $ref: '#/components/schemas/RunRequest'
+                    - $ref: '#/components/schemas/PassportRequest'
           multipart/form-data:
             encoding: { }
             schema:
@@ -330,6 +337,9 @@ paths:
                 - workflow_type_version
                 - workflow_url
         required: true
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -378,6 +388,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -426,6 +439,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -504,6 +520,9 @@ paths:
           explode: true
           schema:
             type: string
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -560,6 +579,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -608,6 +630,9 @@ paths:
           style: simple
           schema:
             type: string
+      security:
+        - BearerAuth: []
+        - {}
       responses:
         200:
           description: ''
@@ -641,7 +666,303 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       deprecated: false
+  /runs/passport:
+    post:
+      tags:
+        - Workflow Runs
+      summary: ListRunsWithPassport
+      description: Same as ListRuns but supports GA4GH passport authentication via POST body. This list should be provided in a stable ordering. When paging through the list, the client should not make assumptions about live updates, but should assume the contents of the list reflect the workflow list at the moment that the request is made.
+      operationId: ListRunsWithPassport
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/PassportRequest'
+                - type: object
+                  properties:
+                    page_size:
+                      type: integer
+                      format: int64
+                      description: OPTIONAL The preferred number of workflow runs to return in a page.
+                    page_token:
+                      type: string
+                      description: OPTIONAL Token to use to indicate where to start getting results.
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunListResponse'
+        400:
+          description: The request is malformed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
+  '/runs/{run_id}/passport':
+    post:
+      tags:
+        - Workflow Runs
+      summary: GetRunLogWithPassport
+      description: Same as GetRunLog but supports GA4GH passport authentication via POST body. This endpoint provides detailed information about a given workflow run.
+      operationId: GetRunLogWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunLog'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested workflow run not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
+  '/runs/{run_id}/status/passport':
+    post:
+      tags:
+        - Workflow Runs
+      summary: GetRunStatusWithPassport
+      description: Same as GetRunStatus but supports GA4GH passport authentication via POST body. This provides an abbreviated status of the running workflow.
+      operationId: GetRunStatusWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunStatus'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested workflow run wasn't found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
+  '/runs/{run_id}/tasks/passport':
+    post:
+      tags:
+        - Workflow Runs
+      summary: ListTasksWithPassport
+      description: Same as ListTasks but supports GA4GH passport authentication via POST body. This endpoint provides a paginated list of tasks that were executed as part of a given workflow run.
+      operationId: ListTasksWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/PassportRequest'
+                - type: object
+                  properties:
+                    page_size:
+                      type: integer
+                      format: int64
+                      description: OPTIONAL The preferred number of task logs to return in a page.
+                    page_token:
+                      type: string
+                      description: OPTIONAL Token to use to indicate where to start getting results.
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskListResponse'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested workflow run wasn't found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
+  '/runs/{run_id}/tasks/{task_id}/passport':
+    post:
+      tags:
+        - Workflow Runs
+      summary: GetTaskWithPassport
+      description: Same as GetTask but supports GA4GH passport authentication via POST body. This endpoint provides information on a specific task.
+      operationId: GetTaskWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+        - name: task_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskLog'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested task wasn't found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Standard OAuth2 bearer token authentication
   schemas:
     ServiceInfo:
       title: ServiceInfo
@@ -1243,6 +1564,20 @@ components:
       required:
         - class
         - value
+    PassportRequest:
+      title: PassportRequest
+      type: object
+      description: Request object for GA4GH passport-based authentication
+      properties:
+        passport:
+          type: array
+          items:
+            type: string
+            format: jwt
+          description: Array of GA4GH passport JWTs for authentication and authorization
+          minItems: 1
+      required:
+        - passport
 
 
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -253,7 +253,7 @@ paths:
 
         1. **`application/json`** (Recommended for workflows submitted by URLs): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows not available as URLs.
 
-        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-encoded string arguments correctly (multipart form submissions only support strings hence the limitation). 
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formatting the JSON-encoded string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -1178,40 +1178,6 @@ components:
           description: Named workflow outputs with structured metadata
           additionalProperties:
             $ref: '#/components/schemas/OutputObject'
-        workflow_metadata:
-          type: object
-          description: Overall workflow execution metadata
-          properties:
-            execution_id:
-              type: string
-              description: Unique identifier for this workflow execution
-            status:
-              $ref: '#/components/schemas/State'
-            start_time:
-              type: string
-              description: Workflow start time in ISO 8601 format
-            end_time:
-              type: string
-              description: Workflow completion time in ISO 8601 format
-            engine:
-              type: string
-              description: Workflow engine used (cromwell, toil, cwltool, nextflow, Snakemake)
-            engine_version:
-              type: string
-              description: Version of the workflow engine
-            resource_usage:
-              type: object
-              description: Resource consumption statistics
-              properties:
-                cpu_hours:
-                  type: number
-                  description: Total CPU hours consumed
-                memory_gb_hours:
-                  type: number
-                  description: Total memory GB-hours consumed
-                disk_gb:
-                  type: number
-                  description: Total disk space used in GB
     OutputObject:
       title: OutputObject
       type: object

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -107,6 +107,14 @@ tags:
     x-displayName: WorkflowEngineVersion
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/WorkflowEngineVersion" />
+  - name: workflowoutputs_model
+    x-displayName: WorkflowOutputs
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/WorkflowOutputs" />
+  - name: outputobject_model
+    x-displayName: OutputObject
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/OutputObject" />
 x-tagGroups:
   - name: Overview
     tags:
@@ -133,6 +141,8 @@ x-tagGroups:
       - defaultworkflowengineparameter_model
       - workflowtypeversion_model
       - workflowengineversion_model
+      - workflowoutputs_model
+      - outputobject_model
 paths:
   /service-info:
     get:
@@ -939,7 +949,10 @@ components:
               specification (2.0.0)
         outputs:
           type: object
-          description: The outputs from the workflow run.
+          description: The outputs from the workflow run (legacy format)
+        structured_outputs:
+          $ref: '#/components/schemas/WorkflowOutputs'
+          description: Structured workflow outputs with rich metadata and type safety
     Log:
       title: Log
       type: object
@@ -1094,8 +1107,118 @@ components:
           description: The integer representing the HTTP status code (e.g. 200, 404).
           format: int32
       description: An object that can optionally include information about the error.
-
-
+    WorkflowOutputs:
+      title: WorkflowOutputs
+      type: object
+      description: Structured workflow outputs with rich metadata and provenance information
+      properties:
+        version:
+          type: string
+          description: Version of the structured outputs format
+          default: "1.0"
+        outputs:
+          type: object
+          description: Named workflow outputs with structured metadata
+          additionalProperties:
+            $ref: '#/components/schemas/OutputObject'
+        workflow_metadata:
+          type: object
+          description: Overall workflow execution metadata
+          properties:
+            execution_id:
+              type: string
+              description: Unique identifier for this workflow execution
+            status:
+              $ref: '#/components/schemas/State'
+            start_time:
+              type: string
+              description: Workflow start time in ISO 8601 format
+            end_time:
+              type: string
+              description: Workflow completion time in ISO 8601 format
+            engine:
+              type: string
+              description: Workflow engine used (cromwell, toil, cwltool, nextflow, snakemake)
+            engine_version:
+              type: string
+              description: Version of the workflow engine
+            resource_usage:
+              type: object
+              description: Resource consumption statistics
+              properties:
+                cpu_hours:
+                  type: number
+                  description: Total CPU hours consumed
+                memory_gb_hours:
+                  type: number
+                  description: Total memory GB-hours consumed
+                disk_gb:
+                  type: number
+                  description: Total disk space used in GB
+    OutputObject:
+      title: OutputObject
+      type: object
+      description: A structured output object with metadata and provenance information
+      properties:
+        class:
+          type: string
+          enum: ["File", "Directory", "Array", "String", "Integer", "Float", "Boolean"]
+          description: Type of the output object
+        value:
+          description: Output value (type depends on class field)
+        location:
+          type: string
+          description: Absolute path or URL to the output file/directory (for File/Directory class)
+        basename:
+          type: string
+          description: Filename without directory path (for File/Directory class)
+        size:
+          type: integer
+          format: int64
+          description: Size in bytes (for File/Directory class)
+        checksum:
+          type: string
+          description: File integrity hash in format 'algorithm:hash' (e.g., 'sha256:abc123...')
+        format:
+          type: string
+          description: MIME type or format identifier (e.g., EDAM ontology reference)
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputObject'
+          description: Array elements (for Array class)
+        metadata:
+          type: object
+          description: Additional metadata about the output
+          properties:
+            created:
+              type: string
+              description: Creation timestamp in ISO 8601 format
+            source_task:
+              type: string
+              description: Task/step that generated this output
+            task_id:
+              type: string
+              description: Unique identifier of the generating task
+            command:
+              type: array
+              items:
+                type: string
+              description: Command line that generated this output
+            description:
+              type: string
+              description: Human-readable description of the output
+        secondary_files:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutputObject'
+          description: Associated files (e.g., index files, companion files)
+        contents:
+          type: string
+          description: File contents for small files (≤64 KiB)
+      required:
+        - class
+        - value
 
 
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -1138,6 +1138,9 @@ components:
                       last_modified:
                         type: string
                         description: Last modification time in ISO 8601 format
+                      credential_id:
+                        type: string
+                        description: Reference to a credential ID defined in the 'credentials' section of the RunRequest. This credential will be used to authenticate and authorize access to this File or Directory resource.
                   description:
                     type: string
                     description: Human-readable parameter description
@@ -1238,6 +1241,17 @@ components:
             OPTIONAL
 
             Additional workflow files required for execution (e.g., imported workflows, subworkflows, or dependencies). Each entry specifies both the source URL and target file path for precise file placement.
+        credentials:
+          type: object
+          description: >-
+            OPTIONAL
+            
+            Named credentials that can be referenced by input parameters that require authentication to access File or Directory resources. Each credential is identified by a unique key and can be referenced multiple times by different parameters to avoid duplicating large authentication tokens.
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/PassportCredential'
+              - $ref: '#/components/schemas/BearerTokenCredential'
+              - $ref: '#/components/schemas/ApiKeyCredential'
       description: >-
         To execute a workflow, send a run request including all the details needed to begin downloading
 
@@ -1581,6 +1595,59 @@ components:
             page_token:
               type: string
               description: OPTIONAL Token to use to indicate where to start getting results.
+    PassportCredential:
+      title: PassportCredential
+      type: object
+      description: GA4GH passport-based credential for accessing restricted resources
+      properties:
+        type:
+          type: string
+          enum: ["passport"]
+          description: Credential type identifier
+        passport:
+          type: array
+          items:
+            type: string
+            format: jwt
+          description: Array of GA4GH passport JWTs for authentication and authorization
+          minItems: 1
+      required:
+        - type
+        - passport
+    BearerTokenCredential:
+      title: BearerTokenCredential
+      type: object
+      description: Bearer token credential for accessing resources
+      properties:
+        type:
+          type: string
+          enum: ["bearer_token"]
+          description: Credential type identifier
+        token:
+          type: string
+          description: Bearer token for authentication
+      required:
+        - type
+        - token
+    ApiKeyCredential:
+      title: ApiKeyCredential
+      type: object
+      description: API key credential for accessing resources
+      properties:
+        type:
+          type: string
+          enum: ["api_key"]
+          description: Credential type identifier
+        key:
+          type: string
+          description: API key for authentication
+        header_name:
+          type: string
+          description: Header name for the API key (defaults to X-API-Key if not specified)
+          default: "X-API-Key"
+      required:
+        - type
+        - key
 
 
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -248,9 +248,15 @@ paths:
     post:
       tags:
         - Workflow Runs
-      summary: RunWorkflow
+      summary: RunWorkflowOrListRuns
       description: |
-        This endpoint creates a new workflow run and returns a `RunId` to monitor its progress.
+        This endpoint supports two operations based on the request body content:
+        
+        1. **Submit Workflow Run**: When request body contains `RunRequest` schema, creates a new workflow run and returns a `RunId` to monitor its progress.
+        
+        2. **List Runs with Passport**: When request body contains `RunsListRequest` schema with GA4GH passport authentication, returns a list of workflow runs (same as GET /runs but with passport auth).
+        
+        **Workflow Submission (RunRequest)**:
 
         **Content Types Supported:**
 
@@ -287,9 +293,7 @@ paths:
             schema:
               oneOf:
                 - $ref: '#/components/schemas/RunRequest'
-                - allOf:
-                    - $ref: '#/components/schemas/RunRequest'
-                    - $ref: '#/components/schemas/PassportRequest'
+                - $ref: '#/components/schemas/RunsListRequest'
           multipart/form-data:
             encoding: { }
             schema:
@@ -342,12 +346,14 @@ paths:
         - {}
       responses:
         200:
-          description: ''
+          description: 'Success - returns either RunId (for workflow submission) or RunListResponse (for passport-based listing)'
           headers: { }
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RunId'
+                oneOf:
+                  - $ref: '#/components/schemas/RunId'
+                  - $ref: '#/components/schemas/RunListResponse'
         400:
           description: The request is malformed.
           content:
@@ -424,6 +430,59 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       deprecated: false
+    post:
+      tags:
+        - Workflow Runs
+      summary: GetRunLogWithPassport
+      description: Same as GetRunLog but supports GA4GH passport authentication via POST body. This endpoint provides detailed information about a given workflow run.
+      operationId: GetRunLogWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunLog'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested workflow run not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
   '/runs/{run_id}/status':
     get:
       tags:
@@ -446,6 +505,59 @@ paths:
         200:
           description: ''
           headers: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunStatus'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested workflow run wasn't found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
+    post:
+      tags:
+        - Workflow Runs
+      summary: GetRunStatusWithPassport
+      description: Same as GetRunStatus but supports GA4GH passport authentication via POST body. This provides an abbreviated status of the running workflow.
+      operationId: GetRunStatusWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
           content:
             application/json:
               schema:
@@ -556,6 +668,59 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       deprecated: false
+    post:
+      tags:
+        - Workflow Runs
+      summary: ListTasksWithPassport
+      description: Same as ListTasks but supports GA4GH passport authentication via POST body. This endpoint provides a paginated list of tasks that were executed as part of a given workflow run.
+      operationId: ListTasksWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TasksListRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskListResponse'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested workflow run wasn't found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
   '/runs/{run_id}/tasks/{task_id}':
     get:
       tags:
@@ -586,6 +751,66 @@ paths:
         200:
           description: ''
           headers: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskLog'
+        401:
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: The requested task wasn't found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      deprecated: false
+    post:
+      tags:
+        - Workflow Runs
+      summary: GetTaskWithPassport
+      description: Same as GetTask but supports GA4GH passport authentication via POST body. This endpoint provides information on a specific task.
+      operationId: GetTaskWithPassport
+      parameters:
+        - name: run_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+        - name: task_id
+          in: path
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PassportRequest'
+      responses:
+        200:
+          description: ''
+          headers: {}
           content:
             application/json:
               schema:
@@ -655,296 +880,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         404:
           description: The requested workflow run wasn't found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        500:
-          description: An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      deprecated: false
-  /runs/passport:
-    post:
-      tags:
-        - Workflow Runs
-      summary: ListRunsWithPassport
-      description: Same as ListRuns but supports GA4GH passport authentication via POST body. This list should be provided in a stable ordering. When paging through the list, the client should not make assumptions about live updates, but should assume the contents of the list reflect the workflow list at the moment that the request is made.
-      operationId: ListRunsWithPassport
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: '#/components/schemas/PassportRequest'
-                - type: object
-                  properties:
-                    page_size:
-                      type: integer
-                      format: int64
-                      description: OPTIONAL The preferred number of workflow runs to return in a page.
-                    page_token:
-                      type: string
-                      description: OPTIONAL Token to use to indicate where to start getting results.
-      responses:
-        200:
-          description: ''
-          headers: {}
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunListResponse'
-        400:
-          description: The request is malformed.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        401:
-          description: The request is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        403:
-          description: The requester is not authorized to perform this action.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        500:
-          description: An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      deprecated: false
-  '/runs/{run_id}/passport':
-    post:
-      tags:
-        - Workflow Runs
-      summary: GetRunLogWithPassport
-      description: Same as GetRunLog but supports GA4GH passport authentication via POST body. This endpoint provides detailed information about a given workflow run.
-      operationId: GetRunLogWithPassport
-      parameters:
-        - name: run_id
-          in: path
-          description: ''
-          required: true
-          style: simple
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PassportRequest'
-      responses:
-        200:
-          description: ''
-          headers: {}
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunLog'
-        401:
-          description: The request is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        403:
-          description: The requester is not authorized to perform this action.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        404:
-          description: The requested workflow run not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        500:
-          description: An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      deprecated: false
-  '/runs/{run_id}/status/passport':
-    post:
-      tags:
-        - Workflow Runs
-      summary: GetRunStatusWithPassport
-      description: Same as GetRunStatus but supports GA4GH passport authentication via POST body. This provides an abbreviated status of the running workflow.
-      operationId: GetRunStatusWithPassport
-      parameters:
-        - name: run_id
-          in: path
-          description: ''
-          required: true
-          style: simple
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PassportRequest'
-      responses:
-        200:
-          description: ''
-          headers: {}
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunStatus'
-        401:
-          description: The request is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        403:
-          description: The requester is not authorized to perform this action.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        404:
-          description: The requested workflow run wasn't found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        500:
-          description: An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      deprecated: false
-  '/runs/{run_id}/tasks/passport':
-    post:
-      tags:
-        - Workflow Runs
-      summary: ListTasksWithPassport
-      description: Same as ListTasks but supports GA4GH passport authentication via POST body. This endpoint provides a paginated list of tasks that were executed as part of a given workflow run.
-      operationId: ListTasksWithPassport
-      parameters:
-        - name: run_id
-          in: path
-          description: ''
-          required: true
-          style: simple
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: '#/components/schemas/PassportRequest'
-                - type: object
-                  properties:
-                    page_size:
-                      type: integer
-                      format: int64
-                      description: OPTIONAL The preferred number of task logs to return in a page.
-                    page_token:
-                      type: string
-                      description: OPTIONAL Token to use to indicate where to start getting results.
-      responses:
-        200:
-          description: ''
-          headers: {}
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskListResponse'
-        401:
-          description: The request is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        403:
-          description: The requester is not authorized to perform this action.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        404:
-          description: The requested workflow run wasn't found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        500:
-          description: An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      deprecated: false
-  '/runs/{run_id}/tasks/{task_id}/passport':
-    post:
-      tags:
-        - Workflow Runs
-      summary: GetTaskWithPassport
-      description: Same as GetTask but supports GA4GH passport authentication via POST body. This endpoint provides information on a specific task.
-      operationId: GetTaskWithPassport
-      parameters:
-        - name: run_id
-          in: path
-          description: ''
-          required: true
-          style: simple
-          schema:
-            type: string
-        - name: task_id
-          in: path
-          description: ''
-          required: true
-          style: simple
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PassportRequest'
-      responses:
-        200:
-          description: ''
-          headers: {}
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskLog'
-        401:
-          description: The request is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        403:
-          description: The requester is not authorized to perform this action.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        404:
-          description: The requested task wasn't found.
           content:
             application/json:
               schema:
@@ -1578,6 +1513,36 @@ components:
           minItems: 1
       required:
         - passport
+    RunsListRequest:
+      title: RunsListRequest
+      type: object
+      description: Request object for listing runs with GA4GH passport authentication
+      allOf:
+        - $ref: '#/components/schemas/PassportRequest'
+        - type: object
+          properties:
+            page_size:
+              type: integer
+              format: int64
+              description: OPTIONAL The preferred number of workflow runs to return in a page.
+            page_token:
+              type: string
+              description: OPTIONAL Token to use to indicate where to start getting results.
+    TasksListRequest:
+      title: TasksListRequest
+      type: object
+      description: Request object for listing tasks with GA4GH passport authentication
+      allOf:
+        - $ref: '#/components/schemas/PassportRequest'
+        - type: object
+          properties:
+            page_size:
+              type: integer
+              format: int64
+              description: OPTIONAL The preferred number of task logs to return in a page.
+            page_token:
+              type: string
+              description: OPTIONAL Token to use to indicate where to start getting results.
 
 
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -299,6 +299,8 @@ paths:
             schema:
               type: object
               properties:
+                passport:
+                  $ref: '#/components/schemas/PassportRequestNotRequired'
                 workflow_params:
                   type: string
                   description: JSON-encoded native workflow parameters (see RunRequest for how to encode)

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -323,7 +323,8 @@ paths:
                   items:
                     type: string
                     format: binary
-                  description: Files to be staged for workflow execution.  You set the filename/path using the Content-Disposition header in the multipart form submission.  For example 'Content-Disposition: form-data; name="workflow_attachment"; filename="workflows/helper.wdl"'.  The files are staged to a temporary directory and can be referenced by relative path in the workflow_url.
+                  description: >-
+                    Files to be staged for workflow execution. You set the filename/path using the Content-Disposition header in the multipart form submission. For example 'Content-Disposition: form-data; name="workflow_attachment"; filename="workflows/helper.wdl"'. The files are staged to a temporary directory and can be referenced by relative path in the workflow_url.
               required:
                 - workflow_type
                 - workflow_type_version
@@ -1102,7 +1103,7 @@ components:
             type: string
           description: An array of one or more acceptable engines versions for the `workflow_engine`. Since a server may support multiple engines and version, the recommendation is to encode this array as '<workflow_engine>_<version>' for clarity.
       description: Available workflow engine versions supported by a given instance of the service.
-  WorkflowEngine:
+    WorkflowEngine:
       title: WorkflowEngine
       type: object
       properties:

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -238,25 +238,40 @@ paths:
       description: >-
         This endpoint creates a new workflow run and returns a `RunId` to monitor its progress.
 
-        The `workflow_attachment` array may be used to upload files that are required to execute the workflow, including the primary workflow, tools imported by the workflow, other files referenced by the workflow, or files which are part of the input.  The implementation should stage these files to a temporary directory and execute the workflow from there. These parts must have a Content-Disposition header with a "filename" provided for each part.  Filenames may include subdirectories, but must not include references to parent directories with '..' -- implementations should guard against maliciously constructed filenames.
+        **Content Types Supported:**
 
-        The `workflow_url` is either an absolute URL to a workflow file that is accessible by the WES endpoint, or a relative URL corresponding to one of the files attached using `workflow_attachment`.
+        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.
 
-        The `workflow_params` JSON object specifies input parameters, such as input files.  The exact format of the JSON object depends on the conventions of the workflow language being used.  Input files should either be absolute URLs, or relative URLs corresponding to files uploaded using `workflow_attachment`.  The WES endpoint must understand and be able to access URLs supplied in the input.  This is implementation specific.
+        2. **`multipart/form-data`**: Legacy format for cases requiring file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.
 
-        The `workflow_type` is the type of workflow language and must be "CWL" or "WDL" currently (or another alternative  supported by this WES instance).
+        **File Handling:**
 
-        The `workflow_type_version` is the version of the workflow language submitted and must be one supported by this WES instance.
+        - **JSON requests**: Files are referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata.
 
-        The `workflow_engine` is the engine that supports the workflow_type and must be supported by this WES instance.
-      
-        The `workflow_engine_version` is the version of workflow engine and must be supported by this WES instance.
+        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security.
 
-        See the `RunRequest` documentation for details about other fields.
+        **Parameter Formats:**
+
+        - **`workflow_params`**: Language-specific parameters (CWL, WDL, Nextflow, SnakeMake format)
+
+        - **`workflow_unified_params`**: Universal parameter format that WES converts to the target workflow language
+
+        **Required Fields:**
+
+        - `workflow_type`: Workflow language ("CWL", "WDL", "Nextflow", "SnakeMake", or other supported types)
+
+        - `workflow_type_version`: Version of the workflow language supported by this WES instance
+
+        - `workflow_url`: Absolute URL to workflow file, or relative path to uploaded attachment
+
+        See the `RunRequest` schema documentation for complete field descriptions and validation rules.
       operationId: RunWorkflow
       parameters: [ ]
       requestBody:
         content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunRequest'
           multipart/form-data:
             encoding: { }
             schema:
@@ -264,27 +279,42 @@ paths:
               properties:
                 workflow_params:
                   type: string
+                  description: JSON-encoded workflow parameters (alternative to using RunRequest model)
+                workflow_unified_params:
+                  type: string
+                  description: JSON-encoded unified workflow parameters (alternative to using RunRequest model)
                 workflow_type:
                   type: string
+                  description: Workflow descriptor type (CWL, WDL, etc.)
                 workflow_type_version:
                   type: string
+                  description: Version of the workflow descriptor type
                 tags:
                   type: string
+                  description: JSON-encoded key-value tags for the workflow run
                 workflow_engine:
                   type: string
+                  description: Workflow engine to use
                 workflow_engine_version:
                   type: string
+                  description: Version of the workflow engine
                 workflow_engine_parameters:
                   type: string
+                  description: JSON-encoded engine-specific parameters
                 workflow_url:
                   type: string
+                  description: URL to the workflow descriptor file
                 workflow_attachment:
                   type: array
                   items:
                     type: string
                     format: binary
-                  description: ''
-        required: false
+                  description: Files to be staged for workflow execution
+              required:
+                - workflow_type
+                - workflow_type_version
+                - workflow_url
+        required: true
       responses:
         200:
           description: ''

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -250,15 +250,15 @@ paths:
 
         **Content Types Supported:**
 
-        1. **`application/json`** (Recommended): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is full schema validation and OpenAPI tooling support along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support multiple workflow file uploads directly, which may be required for multi-file workflows.
+        1. **`application/json`** (Recommended for single workflows submitted by URL): Submit a complete `RunRequest` object with structured data and type validation.  The advantage of this approach is the schema is explicitly defined by OpenAPI syntax (vs. just strings in multipart-form) along with workflow_unified_params object support (see below for more info).  Disadvantage is that it does not support workflow file uploads directly, which may be required for multi-file workflows.
 
-        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads. Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the string encoded arguments correctly (multipart form submissions only support strings hence the limitation). 
+        2. **`multipart/form-data`**: Submit for cases requiring workflow file uploads (rather than just a URL). Fields are JSON-encoded strings that mirror the `RunRequest` structure.  Advantage is you can upload one or more workflow files directly while the disadvantage is you need to be careful in formating the JSON-ended string arguments correctly (multipart form submissions only support strings hence the limitation). 
 
         **File Handling:**
 
         - **JSON requests**: Workflow file is referenced by URL or path. Use `workflow_unified_params` with File objects for rich metadata and generic parameterization.
 
-        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security.
+        - **Multipart requests**: The `workflow_attachment` array uploads files required for workflow execution. Files are staged to a temporary directory with Content-Disposition headers containing filenames. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
 
         **Parameter Formats:**
 
@@ -314,12 +314,15 @@ paths:
                 workflow_url:
                   type: string
                   description: The workflow document. When workflow_attachment is used to attach files, the workflow_url may be a relative path to one of the attachments.
+                additional_workflow_urls:
+                  type: string
+                  description: JSON-encoded array of additional workflow URLs (see RunRequest for how to encode)
                 workflow_attachment:
                   type: array
                   items:
                     type: string
                     format: binary
-                  description: Files to be staged for workflow execution
+                  description: Files to be staged for workflow execution.  You set the filename/path using the Content-Disposition header in the multipart form submission.  For example 'Content-Disposition: form-data; name="workflow_attachment"; filename="workflows/helper.wdl"'.  The files are staged to a temporary directory and can be referenced by relative path in the workflow_url.
               required:
                 - workflow_type
                 - workflow_type_version
@@ -910,6 +913,24 @@ components:
             REQUIRED
 
             The workflow document. When `workflow_attachments` is used to attach files, the `workflow_url` may be a relative path to one of the attachments.
+        additional_workflow_urls:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+                description: URL to the workflow file (absolute URL or relative to uploaded attachments)
+              filename:
+                type: string
+                description: Target filename, possibly including relative path, where this file should be placed e.g. 'workflows/helper.wdl'. Subdirectories are allowed but parent directory references ('..') are prohibited for security purposes.
+            required:
+              - url
+              - filename
+          description: >-
+            OPTIONAL
+
+            Additional workflow files required for execution (e.g., imported workflows, subworkflows, or dependencies). Each entry specifies both the source URL and target file path for precise file placement.
       description: >-
         To execute a workflow, send a run request including all the details needed to begin downloading
 

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -795,9 +795,10 @@ components:
         workflow_params:
           type: object
           description: >-
-            REQUIRED (unless workflow_unified_params provided)
+            OPTIONAL
 
-            The workflow run parameterizations (JSON encoded), including input and output file locations
+            The workflow run parameterizations (JSON encoded), including input and output file locations.
+            Either `workflow_params` or `workflow_unified_params` must be provided, but not both.
         workflow_unified_params:
           type: object
           description: >-


### PR DESCRIPTION
# Overview 

This pull request updates the Workflow Execution Service (WES) OpenAPI specification (starting with #226) to enhance functionality in several key ways without creating breaking changes (hopefully). Key changes include 1) adding POST endpoints to support authentication/authorizing with a GA4GH Passport rather than a bearer token, 2) providing credentials for a WES server to access DRS (or other) inputs, and 3) for providing back credentials for the output of the workflow run to be accessible.  Claude Code was used to generate some of these changes.

**Related issues**

- https://github.com/ga4gh/workflow-execution-service-schemas/issues/18
- https://github.com/ga4gh/workflow-execution-service-schemas/issues/131 
- https://github.com/ga4gh/workflow-execution-service-schemas/issues/156

 **Related Standards** 

This implementation aligns with:

- [GA4GH Passport Specification](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md)
- [GA4GH DRS Specification](https://ga4gh.github.io/data-repository-service-schemas/) for
  data access patterns
- [WES 1.1.0 Specification](https://ga4gh.github.io/workflow-execution-service-schemas/docs/)
  for backward compatibility

**Related PR**

The feature branch behind this PR is based on `feature/issue-176-wes-params` and not `develop` since I was building off of the structured input/output.  See #226 

**eLwazi-hosted GA4GH Hackathon**

The eLwazi hosted GA4GH hackathon 7/28-8/1 is working on this issue given the need by various groups attending the session.  For more info, see the [agenda](https://docs.google.com/document/d/1z-2Uj2R9-yLt1fTfohdUBg-kPFfxXpkWSCZz6NrACwY/edit?tab=t.0#heading=h.g7tx7vgfgncd). 

**Built Documentation**

The human-readable documentation: https://ga4gh.github.io/workflow-execution-service-schemas/preview/feature/issue-18-data-access-creds/docs/index.html

## Issues/questions for discussion
- See security and implementation sections below...
- Do passport visas need to evolve to be useful for using passports as an AuthN/Z token for making WES requests?  Right now, I know of Passports being used with visas that specifically talk about data access but the changes made in this PR open up using Passports for compute.
- Is it better to have a `POST /runs/list` endpoint instead of overloading `POST /runs` based on what request body schema is used?
- In previous conversations, the idea of delegating tokens to a WES service brought up security concerns.  I think it's a valid point however we see examples with Driver projects of Passports being used in this way... retrieved by one service from the passport broken and handed to another service for data access.  So it's a concern but I think we need to weigh the positives with negatives here and realize one security profile doesn't meet every implementers needs.
- do we need to make it more explicit in the schema that supporting passports is optional?  A service may choose to not implement passports at all and they are still a valid WES.  Do we need an error code.  For example:
  - 405 Method Not Allowed - The endpoint exists, but the HTTP method (GET, POST, etc.) is
  not supported... useful for the POST endpoints on existing paths.
  - 501 Not Implemented - The endpoint is defined but not yet implemented by the server. Maybe this is the response for POST /runs when trying to list runs with a passport when that's not implemented?
- Do we need something in service-info that says this server supports POSTs w/ Passports or not?
- Do we need something in service-info to say the WES server supports delegated credentials? And more generally, the structured inputs/outputs.
- What's required?  Does every WES 1.2 server need to support DRS+HTTP URLs with auth for inputs?  For outputs the server isn't really mandated to use DRS or even HTTP outputs.
- in this PR, outputs are deposited (potentially) in a location and credentials (if applicable) are handed back to the WES caller.  However, do we want a mode additionally where the submitter tells WES where they want the outputs to be written to (along with credentials to push data there)?

## Authentication/Authorization for WES Requests 

I followed the same pattern here as used in [DRS](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/), making POST methods for existing endpoints that now support including a passport array in the body.  These mirror the existing GET endpoints that use a bearer token.

### Making Requests

Here's an example showing a bearer token request vs. the Passport in body request:

```
#  Bearer Token (existing):
  curl -H "Authorization: Bearer <token>" https://wes.example.com/ga4gh/wes/v1/runs

#  GA4GH Passport (new):
  curl -X POST https://wes.example.com/ga4gh/wes/v1/runs/passport \
    -H "Content-Type: application/json" \
    -d '{"passport": ["<jwt1>", "<jwt2>"]}'
```

### POST and /runs endpoint 

This approach makes the `/runs` endpoint complicated.  It feels overloaded since it's doing multiple things:

- if you do a `GET /runs` with a bearer token it's a list of runs
- if you do a `POST /runs` with a bearer token (or Passport in the body) and either `application/json` body schema of type `PassportRunRequest` or `multipart/form-data` you get a new workflow run
- if you do a `POST /runs` with a passport in the body using `application/json` body schema of type `RunListRequest` then you get a list of runs 

So it might be more clear if we have a `POST /runs/list` endpoint instead... so `/runs` is less overloaded.

## Sending Credentials

In addition to adding support for Passports in WES requests (as an alternative to bearer tokens), this PR includes syntax extensions to allow for providing credentials to access inputs and pass back credentials so callers can access outputs.

### Data Inputs

Here's how a client would structure a workflow submission:

```
  {
    "workflow_type": "WDL",
    "workflow_type_version": "1.0",
    "workflow_url": "https://example.com/workflow.wdl",

    "credentials": {
      "tcga_passport": {
        "type": "passport",
        "passport": ["eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1N..."]
      },
      "s3_token": {
        "type": "bearer_token",
        "token": "aws-token-here..."
      },
      "api_access": {
        "type": "api_key",
        "key": "abc123",
        "header_name": "X-Custom-Key"
      }
    },

    "workflow_unified_params": {
      "version": "1.0",
      "parameters": {
        "input_bam": {
          "type": "File",
          "value": "drs://drs.example.org/abc123",
          "file_metadata": {
            "credential_id": "tcga_passport",
            "size": 1000000,
            "checksum": "sha256:abc123..."
          }
        },
        "reference_genome": {
          "type": "File",
          "value": "s3://bucket/reference.fa",
          "file_metadata": {
            "credential_id": "s3_token"
          }
        },
        "public_annotation": {
          "type": "File",
          "value": "https://public.example.com/annotation.bed"
          // No credential_id needed for public files
        }
      }
    }
  }

```

### Data Outputs

Now GetRunLog responses can include credentials for accessing outputs:

```
{
    "run_id": "workflow-123",
    "state": "COMPLETE",

    "output_credentials": {
      "s3_output_access": {
        "type": "bearer_token",
        "token": "aws-s3-token-456..."
      },
      "restricted_results": {
        "type": "passport",
        "passport": ["eyJ0eXAiOiJKV1QiLCJhbGci..."]
      }
    },

    "structured_outputs": {
      "version": "1.0",
      "outputs": {
        "result_bam": {
          "class": "File",
          "location": "s3://results-bucket/output.bam",
          "credential_id": "s3_output_access",
          "size": 2000000,
          "checksum": "sha256:def456..."
        },
        "analysis_report": {
          "class": "File",
          "location": "drs://restricted.example.org/report123",
          "credential_id": "restricted_results",
          "format": "application/pdf"
        },
        "public_summary": {
          "class": "File",
          "location": "https://public.example.com/summary.txt"
          // No credential_id needed for public files
        }
      }
    }
  }

```

## Security Considerations

- Credentials are only included in responses when the requesting client is authorized to
  access the outputs.  We need to really think about how this works for Passports since typically these are issued through an OIDC flow and not just handed around.  API keys and bearer tokens are a little easier since it would be possible to issue temporary/limited scoped tokens.
- Large passport JWTs are defined once and referenced multiple times to minimize request/response size... this should help with performance issues (less a security concern)
- Credential scope should be limited to specific file resources, not broad system access... helps to address the concern about passing around powerful tokens.  If possible, Passports passed in for inputs access could be downscoped to just include visas relevant to the files in the inputs.
- It's unclear if WES servers should validate passport signatures and visa claims before using the passports for inputs access.  I suspect not but something to discuss
- This implementation assumes you can pass your passport/token/api key to another system and have that system use it on your behalf.  This would work fine in the DRS world except if there's an additional trust layer implemented (as some Driver Projects are discussing).  In this case, the WES server might not be trusted by the DRS server and, even with having a correct Passport, might be denied access to files.  This is a fluid topic, we don't have a clear trust mechanism but if trust mechanisms do get implemented (either in the specs or outside) it could affect the model presented in this PR of being able to pass around credentials.

## Implementation Notes

- **Passport Support**: WES servers MAY implement passport authentication (not required)
- **Credential Types**: Servers SHOULD support at least bearer tokens, MAY support
  passport credentials
- **Delegated Credentials**: Servers MUST support DRS and HTTP URLs for delegated credentials
- **Backward Compatibility**: All existing authentication methods MUST continue to work.  The current inputs/multipart/form-data and output approaches need to continue to work.  So a WES 1.1 client should be able to work with a WES 1.2 server without modification.
- **Error Handling**: Servers should return appropriate HTTP status codes for credential
  failures.