### PR TITLE
fix timeout problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
     steps:
       - name: Check out head branch
         uses: actions/checkout@v4
-      - name: Run OpenAPI Validate Action
-        uses: swaggerexpert/swagger-editor-validate@v1.5.1
-        env:
-          PUPPETEER_NO_SANDBOX: "true"
-          PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chromium-browser"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          definition-file: openapi/workflow_execution_service.openapi.yaml
+          node-version: '20'
+      - name: Install Spectral
+        run: npm install -g @stoplight/spectral-cli
+      - name: Validate OpenAPI definition
+        run: spectral lint openapi/workflow_execution_service.openapi.yaml --ruleset .spectral.yaml

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,3 @@
+extends: spectral:oas
+rules:
+  info-contact: off

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -143,32 +143,32 @@ paths:
       operationId: GetServiceInfo
       parameters: [ ]
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceInfo'
-        400:
+        '400':
           description: The request is malformed.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -199,32 +199,32 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RunListResponse'
-        400:
+        '400':
           description: The request is malformed.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -286,32 +286,32 @@ paths:
                   description: ''
         required: false
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RunId'
-        400:
+        '400':
           description: The request is malformed.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -334,32 +334,32 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RunLog'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
+        '404':
           description: The requested workflow run not found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -382,32 +382,32 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RunStatus'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
+        '404':
           description: The requested workflow run wasn't found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -460,32 +460,32 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: ''
           headers: {}
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskListResponse'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
+        '404':
           description: The requested workflow run wasn't found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -516,32 +516,32 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskLog'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
+        '404':
           description: The requested task wasn't found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:
@@ -564,32 +564,32 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: ''
           headers: { }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RunId'
-        401:
+        '401':
           description: The request is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        403:
+        '403':
           description: The requester is not authorized to perform this action.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
+        '404':
           description: The requested workflow run wasn't found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: An unexpected error occurred.
           content:
             application/json:


### PR DESCRIPTION
## Summary

This pull request addresses a timeout issue that was occurring during the build and validation process for the Workflow Execution Service (WES) schema. It includes updates to the CI workflow configuration, Spectral linting rules, and the OpenAPI schema itself.

### What Changed
-  CI workflow adjustments

- Updated the .github/workflows/ci.yml file to modify one or more steps that were likely causing GitHub Actions to time out.


## Spectral lint configuration updated

Introduced a .spectral.yaml config to enforce consistent linting rules or to disable rules that weren’t appropriate for this API.

This change supports successful linting of the OpenAPI spec in CI without false positives.

##  OpenAPI spec refinements

- The openapi/workflow_execution_service.openapi.yaml spec was modified (around 80 additions & deletions).
