### PR TITLE
Extract common log base schema for WES/TES harmonization

### DIFF
--- a/openapi/common_log_base.yaml
+++ b/openapi/common_log_base.yaml
@@ -1,0 +1,37 @@
+components:
+  schemas:
+    LogBase:
+      title: LogBase
+      description: >-
+        Base log schema shared between WES Log and TES tesExecutorLog.
+        See https://github.com/ga4gh/workflow-execution-service-schemas/issues/217
+      type: object
+      properties:
+        start_time:
+          type: string
+          description: >-
+            When the command started executing,
+            in ISO 8601 / RFC 3339 format
+          example: "2020-10-02T10:00:00-05:00"
+        end_time:
+          type: string
+          description: >-
+            When the command stopped executing (completed, failed, or cancelled),
+            in ISO 8601 / RFC 3339 format
+          example: "2020-10-02T11:00:00-05:00"
+        stdout:
+          type: string
+          description: >-
+            Stdout content or a URL to retrieve it.
+            No guarantees are made about completeness - implementations
+            may return only head/tail or a URL reference.
+        stderr:
+          type: string
+          description: >-
+            Stderr content or a URL to retrieve it.
+            No guarantees are made about completeness - implementations
+            may return only head/tail or a URL reference.
+        exit_code:
+          type: integer
+          format: int32
+          description: Exit code of the program

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -826,47 +826,32 @@ components:
           description: The outputs from the workflow run.
     Log:
       title: Log
-      type: object
-      properties:
-        name:
-          type: string
-          description: The task or workflow name
-        cmd:
-          type: array
-          items:
-            type: string
-          description: The command line that was executed
-        start_time:
-          type: string
-          description: When the command started executing, in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
-        end_time:
-          type: string
-          description: When the command stopped executing (completed, failed, or cancelled), in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
-        stdout:
-          type: string
-          description: A URL to retrieve standard output logs of the workflow run or task.  This URL may change between status requests, or may not be available until the task or workflow has finished execution.  Should be available using the same credentials used to access the WES endpoint.
-        stderr:
-          type: string
-          description: A URL to retrieve standard error logs of the workflow run or task.  This URL may change between status requests, or may not be available until the task or workflow has finished execution.  Should be available using the same credentials used to access the WES endpoint.
-        exit_code:
-          type: integer
-          description: Exit code of the program
-          format: int32
-        system_logs:
-          type: array
-          items:
-            type: string
-
-          description: |-
-            System logs are any logs the system decides are relevant,
-            which are not tied directly to a workflow.
-            Content is implementation specific: format, size, etc.
-
-            System logs may be collected here to provide convenient access.
-
-            For example, the system may include an error message that caused
-            a SYSTEM_ERROR state (e.g. disk is full), etc.
       description: Log and other info
+      allOf:
+        - $ref: 'common_log_base.yaml#/components/schemas/LogBase'
+        - type: object
+          properties:
+            name:
+              type: string
+              description: The task or workflow name
+            cmd:
+              type: array
+              items:
+                type: string
+              description: The command line that was executed
+            system_logs:
+              type: array
+              items:
+                type: string
+              description: |-
+                System logs are any logs the system decides are relevant,
+                which are not tied directly to a workflow.
+                Content is implementation specific: format, size, etc.
+
+                System logs may be collected here to provide convenient access.
+
+                For example, the system may include an error message that caused
+                a SYSTEM_ERROR state (e.g. disk is full), etc.
     DefaultWorkflowEngineParameter:
       title: DefaultWorkflowEngineParameter
       type: object


### PR DESCRIPTION
WES `Log` and TES `tesExecutorLog` share the same core fields (start_time, end_time, stdout, stderr, exit_code) but diverged over time into separate definitions. this makes it harder to build clients that work with both APIs extracted the shared fields into `common_log_base.yaml` as a `LogBase` schema, and refactored WES `Log` to extend it via allOf. TES can reference the same base on their side

the descriptions are unified to cover both use cases — WES uses URLs for stdout/stderr while TES may return content directly, so the base description accounts for both

relates to #217

I emailed gsoc-mentors-2025@ga4gh.org about GSoC 2026 (knqzx0@gmail.com)