### PR TITLE
Add filtering support for GET /runs endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file: openapi/workflow_execution_service.openapi.yaml
+
   diff:
     name: Show OpenAPI differences relative to target branch
     runs-on: ubuntu-latest
@@ -49,3 +50,29 @@ jobs:
         run: npm install -g @stoplight/spectral-cli
       - name: Validate OpenAPI definition
         run: spectral lint openapi/workflow_execution_service.openapi.yaml --ruleset .spectral.yaml
+
+  validate-filtering-spec:
+    name: Validate Filtering Specification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install OpenAPI validator
+        run: npm install -g @apidevtools/swagger-cli
+      
+      - name: Validate OpenAPI spec
+        run: swagger-cli validate openapi/workflow_execution_service.openapi.yaml
+      
+      - name: Check filtering parameters are documented
+        run: |
+          # Ensure filtering guide exists and covers key parameters
+          grep -q "state" docs/filtering-guide.md
+          grep -q "tag" docs/filtering-guide.md
+          grep -q "since" docs/filtering-guide.md
+          echo "✅ Filtering documentation is complete"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,21 @@
 View the full [Reference Documentation](https://ga4gh.github.io/workflow-execution-service-schemas/docs/) for the Workflow Execution Service API.
+
+
+## Filtering Workflow Runs
+
+WES supports filtering the `GET /runs` endpoint to efficiently query specific workflows without retrieving all runs.
+
+**Quick examples:**
+
+```bash
+# Get running workflows
+GET /runs?state=RUNNING
+
+# Get failed workflows from last 24 hours
+GET /runs?state=EXECUTOR_ERROR&since=2025-01-08T00:00:00Z
+
+# Search by workflow name
+GET /runs?workflow_name=alignment
+
+# Filter by tags
+GET /runs?tag=batch:12345&tag=project:cancer

--- a/docs/filtering-guide.md
+++ b/docs/filtering-guide.md
@@ -1,0 +1,13 @@
+# Filtering Workflow Runs
+
+The WES API supports filtering workflow runs via query parameters on the `GET /runs` endpoint.
+
+## Filter Parameters
+
+### By State
+
+Filter by workflow execution state. Multiple states use OR logic.
+
+**Single state:**
+```bash
+GET /runs?state=RUNNING

--- a/openapi/workflow_execution_service.openapi.yaml
+++ b/openapi/workflow_execution_service.openapi.yaml
@@ -19,14 +19,14 @@ info:
     + can get information about running workflows (e.g. status, errors, output file locations)
     + can cancel a running workflow
 servers:
-- url: https://{defaultHost}/{basePath}/{apiVersion}
-  variables:
-    defaultHost:
-      default: www.example.com
-    basePath:
-      default: ga4gh/wes
-    apiVersion:
-      default: v1
+  - url: https://{defaultHost}/{basePath}/{apiVersion}
+    variables:
+      defaultHost:
+        default: www.example.com
+      basePath:
+        default: ga4gh/wes
+      apiVersion:
+        default: v1
 tags:
   - name: Service Info
     description: Get information about the workflow execution service
@@ -141,11 +141,11 @@ paths:
       summary: GetServiceInfo
       description: May include information related (but not limited to) the workflow descriptor formats, versions supported, the WES API versions supported, and information about general service availability.
       operationId: GetServiceInfo
-      parameters: [ ]
+      parameters: []
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -183,6 +183,7 @@ paths:
       description: This list should be provided in a stable ordering. (The actual ordering is implementation dependent.) When paging through the list, the client should not make assumptions about live updates, but should assume the contents of the list reflect the workflow list at the moment that the first page is requested.  To monitor a specific workflow run, use GetRunStatus or GetRunLog.
       operationId: ListRuns
       parameters:
+        # Existing pagination parameters
         - name: page_size
           in: query
           description: OPTIONAL The preferred number of workflow runs to return in a page. If not provided, the implementation should use a default page size. The implementation must not return more items than `page_size`, but it may return fewer.  Clients should not assume that if fewer than `page_size` items are returned that all items have been returned.  The availability of additional pages is indicated by the value of `next_page_token` in the response.
@@ -198,10 +199,140 @@ paths:
           explode: true
           schema:
             type: string
+        
+        # NEW FILTERING PARAMETERS
+        - name: state
+          in: query
+          description: |
+            OPTIONAL
+            Filter by workflow state. Multiple values may be provided to match 
+            any of the specified states (OR logic). If not provided, returns 
+            runs in all states.
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/State'
+          examples:
+            single:
+              value: RUNNING
+              summary: Get running workflows only
+            multiple:
+              value: [RUNNING, QUEUED]
+              summary: Get running or queued workflows
+        
+        - name: workflow_type
+          in: query
+          description: |
+            OPTIONAL
+            Filter by workflow type (e.g., "CWL", "WDL"). Exact match.
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: "WDL"
+        
+        - name: workflow_type_version
+          in: query
+          description: |
+            OPTIONAL
+            Filter by workflow type version. Exact match.
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: "1.0"
+        
+        - name: workflow_engine
+          in: query
+          description: |
+            OPTIONAL
+            Filter by workflow engine name. Exact match.
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: "Cromwell"
+        
+        - name: workflow_url
+          in: query
+          description: |
+            OPTIONAL
+            Filter by workflow URL. Exact match.
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: uri
+          example: "https://github.com/user/workflow.wdl"
+        
+        - name: tag
+          in: query
+          description: |
+            OPTIONAL
+            Filter by tags using key:value syntax. Multiple tags are ANDed 
+            (run must have ALL specified tags). Tags are matched against the 
+            tags field in the RunRequest.
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              pattern: '^[^:]+:[^:]+$'
+          examples:
+            single:
+              value: "batch:12345"
+              summary: Filter by single tag
+            multiple:
+              value: ["batch:12345", "project:cancer-genomics"]
+              summary: Filter by multiple tags (must have both)
+        
+        - name: since
+          in: query
+          description: |
+            OPTIONAL
+            Filter runs that started on or after this timestamp. 
+            Uses ISO 8601 format "%Y-%m-%dT%H:%M:%SZ".
+            Filters based on the run's start_time field.
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: date-time
+          example: "2025-01-01T00:00:00Z"
+        
+        - name: until
+          in: query
+          description: |
+            OPTIONAL
+            Filter runs that started before this timestamp.
+            Uses ISO 8601 format "%Y-%m-%dT%H:%M:%SZ".
+            Filters based on the run's start_time field.
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: date-time
+          example: "2025-12-31T23:59:59Z"
+        
+        - name: search
+          in: query
+          description: |
+            OPTIONAL
+            Full-text search across workflow metadata. Implementation-specific 
+            behavior. Does NOT search log contents. May search workflow name, 
+            tags, or other metadata fields as determined by the implementation.
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: "cancer genome alignment"
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -254,11 +385,11 @@ paths:
 
         See the `RunRequest` documentation for details about other fields.
       operationId: RunWorkflow
-      parameters: [ ]
+      parameters: []
       requestBody:
         content:
           multipart/form-data:
-            encoding: { }
+            encoding: {}
             schema:
               type: object
               properties:
@@ -288,7 +419,7 @@ paths:
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -336,7 +467,7 @@ paths:
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -384,7 +515,7 @@ paths:
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -518,7 +649,7 @@ paths:
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -566,7 +697,7 @@ paths:
       responses:
         '200':
           description: ''
-          headers: { }
+          headers: {}
           content:
             application/json:
               schema:
@@ -738,9 +869,9 @@ components:
       title: RunRequest
       type: object
       required:
-      - workflow_type
-      - workflow_type_version
-      - workflow_url
+        - workflow_type
+        - workflow_type_version
+        - workflow_url
       properties:
         workflow_params:
           type: object
@@ -816,11 +947,11 @@ components:
             anyOf:
               - $ref: '#/components/schemas/Log'
               - $ref: '#/components/schemas/TaskLog'
-          description:  >-
-              The logs, and other key info like timing and exit code, for each step in the workflow run.
-              This field is deprecated and the `task_logs_url` should be used to retrieve a paginated list
-              of steps from the workflow run. This field will be removed in the next major version of the 
-              specification (2.0.0)
+          description: >-
+            The logs, and other key info like timing and exit code, for each step in the workflow run.
+            This field is deprecated and the `task_logs_url` should be used to retrieve a paginated list
+            of steps from the workflow run. This field will be removed in the next major version of the 
+            specification (2.0.0)
         outputs:
           type: object
           description: The outputs from the workflow run.
@@ -856,7 +987,6 @@ components:
           type: array
           items:
             type: string
-
           description: |-
             System logs are any logs the system decides are relevant,
             which are not tied directly to a workflow.
@@ -919,7 +1049,6 @@ components:
               type: array
               items:
                 type: string
-
               description: |-
                 System logs are any logs the system decides are relevant,
                 which are not tied directly to a task.
@@ -966,10 +1095,10 @@ components:
           description: >-
             Total count of workflow runs that the service has executed or is executing and the caller has permission to see.
       description: >
-              The service will return a RunListResponse when receiving a successful RunListRequest.
-              DEPRECIATION WARNING: The use of `RunStatus` as the schema for `runs` array items will
-              not be permitted from the next major version of the specification (2.0.0) onwards. We
-              encourage implementers to use `RunSummary` instead.
+        The service will return a RunListResponse when receiving a successful RunListRequest.
+        DEPRECIATION WARNING: The use of `RunStatus` as the schema for `runs` array items will
+        not be permitted from the next major version of the specification (2.0.0) onwards. We
+        encourage implementers to use `RunSummary` instead.
     ErrorResponse:
       title: ErrorResponse
       type: object
@@ -982,10 +1111,3 @@ components:
           description: The integer representing the HTTP status code (e.g. 200, 404).
           format: int32
       description: An object that can optionally include information about the error.
-
-
-
-
-
-
-


### PR DESCRIPTION
hi @patmagee 
Closes:  issue  #230

Summary
This PR adds filtering support to the GET /runs endpoint in order to overcome scalability issues related to the filtering of workflow runs. Currently the api does not expose any options to filter runs and all runs must be retrieved without filtering capabilities. This becomes a bottleneck for an implementation that keeps track of a large quantity of workflows.

Changes
I have added 9 optional query parameters to the GET /runs endpoint:

state - Filter based on the workflow state, uses OR logic
workflow_type - Filter based on the workflow language
workflowtypeversion - Filter based on the workflow language version
workflow_engine - Filter based on the execution engine
workflow_url - Filter based on the workflow URL
tag - Filter based on the tags, uses AND logic with the format key:value
since / until - Filter based on the start time. Only allows filtering based on date ranges (inclusive).

Search - Full text search based on the implementation, not detailed by the API spec (will filter based on workflow id, name or definition. What is searched will differ per API implementation).

Filtering logic:
Multiple state values are ANDed together with OR logic. For example a call to /runs?state=RUNNING&state=QUEUED would search for running OR queued jobs.
Multiple tag values are ANDed together with AND logic. For example a call to /runs?tag=env:production&tag=component:database would search for production AND database jobs.
Different parameter types are ANDed together. For example a call to /runs?workflow_type=javascript&state=QUEUED&tag=env:development would search forjavascript and queued and development jobs.

Example:
BashGET /runs?state=RUNNING&state=QUEUED&tag=env:production

Files :

openapi/workflowexecutionservice.openapi.yaml - Filter parameters added to the /runs endpoint
docs/README.md - A section has been added covering filtering the API
.github/workflows/ci.yml - Added a validation job for the documentation covering filtering


Backward Compatibility
All new parameters added to the API are optional and do not affect backward compatibility.Existing API clients will be completely unaffected.
Validation
