### PR TITLE
docs: fix GitHub Pages blockquote in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,14 @@ against an execution backend.
 
 See the human-readable [Reference Documentation](https://ga4gh.github.io/workflow-execution-service-schemas/docs/)
 You can also explore the specification in
-the [Swagger Editor](https://editor.swagger.io/?url=https://ga4gh.github.io/workflow-execution-service-schemas/openapi.yaml)**
+the [Swagger Editor](https://editor.swagger.io/?url=https://ga4gh.github.io/workflow-execution-service-schemas/openapi.yaml).
 *Manually load the JSON if working from a non-develop branch version.* Preview documentation from
 the [gh-openapi-docs](https://github.com/ga4gh/gh-openapi-docs) for the development
 branch [here](https://ga4gh.github.io/workflow-execution-service-schemas/preview/develop/docs/index.html)
 
-> All documentation and pages hosted at 'ga4gh.github.io/workflow-execution-service' reflect the latest API release from
-> the `master` branch. To monitor the latest development work, add 'preview/\<branch\>' to the URLs above (e.g., '
-> ga4gh.github.io/ga4gh.github.io/workflow-execution-service/preview/\<branch\>/docs'). To view the latest *stable*
-> development API specification, refer to the `develop` branch.
+> All documentation and pages hosted at `ga4gh.github.io/workflow-execution-service-schemas` reflect the latest API release from
+> the `master` branch. To monitor the latest development work for a given branch, add `preview/<branch>/` after the site path (for example,
+> `https://ga4gh.github.io/workflow-execution-service-schemas/preview/develop/docs/`). To view the latest stable development API specification, refer to the `develop` branch.
 
 
 The [Global Alliance for Genomics and Health](http://genomicsandhealth.org/) is an international coalition, formed to


### PR DESCRIPTION
## Description

This PR fixes the README note about documentation hosted on GitHub Pages.

**What was wrong**

- The hosted site was named `workflow-execution-service` instead of `workflow-execution-service-schemas`.
- The example URL duplicated the host (`ga4gh.github.io/ga4gh.github.io/...`).
- The blockquote was split across lines in a way that broke the example and made it hard to read.
- The Swagger Editor line had stray `**` after the link (invalid Markdown).

**What changed**

- Correct site name and a single, clear example URL (`.../preview/develop/docs/`).
- Blockquote rewritten as short, readable sentences.
- Stray `**` removed; the Swagger Editor sentence ends with a period.

**How to verify**

- Open `README.md` on the branch and confirm the blockquote and Swagger Editor line render correctly on GitHub.

## Checklist (optional)

- [ ] Target branch is `develop`
- [ ] No unrelated files changed